### PR TITLE
Fix "thrown" typo

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1048,8 +1048,8 @@ In truth, all content in ink is a weave, even if there are no gathers in sight. 
 	=== fight_guard ===
 	...
 	= throw_something 
-	*	(rock) [Throw rock at guard] -> thrown
-	* 	(sand) [Throw sand at guard] -> thrown
+	*	(rock) [Throw rock at guard] -> throw
+	* 	(sand) [Throw sand at guard] -> throw
 
 	= throw
 	You hurl {throw_something.rock:a rock|a handful of sand} at the guard.


### PR DESCRIPTION
in "Advanced: all options can be labelled"