### PR TITLE
Fixes typo in the first tunnels example

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1716,7 +1716,7 @@ But this flat structure makes certain things difficult: for example, imagine a g
 	=== outside_honolulu ===
 	We arrived at the large island of Honolulu.
 	- (postscript) 
-		{crossing_the_date_line(-> done) 
+		{crossing_the_date_line(-> done)} 
 	- (done)
 		-> END 
 
@@ -1725,7 +1725,7 @@ But this flat structure makes certain things difficult: for example, imagine a g
 	=== outside_pitcairn_island ===
 	The boat sailed along the water towards the tiny island.
 	- (postscript) 
-		{crossing_the_date_line(-> done) 
+		{crossing_the_date_line(-> done)} 
 	- (done)
 		-> END 
 	


### PR DESCRIPTION
This seems like it is a typo, if my understanding of the function syntax is correct.