### PR TITLE
Add support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: csharp
+solution: ink.sln
+install:
+  - sudo apt-get install nunit-console
+before_script:
+  - nuget restore ink.sln
+after_script:
+  - nunit-console tests/bin/Debug/tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ install:
   - sudo apt-get install nunit-console
 before_script:
   - nuget restore ink.sln
-after_script:
+script:
+  - xbuild ink.sln
   - nunit-console tests/bin/Debug/tests.dll

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ink
 
 [![HipChat](http://www.inklestudios.com/img/ink-github-HipChat-widget.svg)](https://www.hipchat.com/gkq2pSLqU)
+[![CI Status](http://img.shields.io/travis/inkle/ink.svg?style=flat)](https://travis-ci.org/inkle/ink)
 
 Ink is [inkle](http://www.inklestudios.com/)'s scripting language for writing interactive narrative, both for text-centric games as well as more graphical games that contain highly branching stories. It's designed to be easy to learn, but with powerful enough features to allow an advanced level of structuring.
 


### PR DESCRIPTION
Hi!

This pull request adds support for the [Travis-CI](https://travis-ci.org) continuous integration service. If you go onto Travis and enable this repo (it's free for OSS projects), it'll automatically build the app and run the tests every time a new commit hits master. You can also set up a GitHub integration to automatically run a CI build against any incoming pull requests, and warns you if it would cause the build to break. (These are both things you'll have to do as the repo owner, but they should take < 5 min. Happy to walk you through them, but they're incredibly straight-forward.). This also adds a nice little badge to the README showing the current build status. I've tested this on my own fork, including adding/removing a failing test case to make sure that Travis failed/passed the build.

In my experience, having a CI service is incredibly useful for soliciting open-source contributions, since it helps ensure that people are submitting code that actually, well, compiles. I've also seen some discussion in the GH Issues about automated testing solutions moving forward, and having a CI setup is a pretty key step towards that. If you have strong opinions about other CI solutions, that's awesome, but otherwise Travis is generally the de facto standard for OSS projects on GitHub these days.