### PR TITLE
Add .gitattributes, remove Tests.cs comment.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# All files will always convert to LF line endings upon checkin.
+* text eol=lf

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -3,21 +3,6 @@ using Ink;
 using Ink.Runtime;
 using System.Collections.Generic;
 
-/*
- * WINDOWS USERS:
- *
- * If certain string comparison tests are failing and the details are similar to: 
- *      Expected: "a\r\nb  \r\nc" But was: "a\nb  \nc"
- * this means your system has changed the line endings in this file in a way that breaks these tests.
- *
- * You'll need to restore this file to use LF (i.e, "\n") line terminations to fix this problem. 
- * (In Visual Studio, you can do this using File -> Advanced Save Options. You'll probably want to correct 
- * the root cause of the problem rather than resaving the file repeatedly, though.)
- *
- * One way you can run into this issue is if you have Git configured with core.autocrlf = true,
- * which automatically converts \n to \r\n upon checkout. Some Git for Windows packages install with this setting set to true.
- */
-
 namespace Tests
 {
     public enum TestMode


### PR DESCRIPTION
This has the changes I talked about in https://github.com/inkle/ink/issues/45 . Basically this should guard against accidentally CRLFing Tests.cs, and over time will bring other files into consistent LF format (currently the source tree mixed LF and CRLF). See longer discussion in the issue.
