### PR TITLE
Invalidate cache of targetContent

### DIFF
--- a/ink-engine-runtime/Divert.cs
+++ b/ink-engine-runtime/Divert.cs
@@ -17,6 +17,7 @@ namespace Ink.Runtime
             }
             set {
                 _targetPath = value;
+                _targetContent = null;
             } 
         }
         Path _targetPath;


### PR DESCRIPTION
targetContent caches the result of resolving _targetPath, but the cache never invalidates, so targetContent, and in some cases, targetPath, can be stale. This change invalidates the cache when _targetPath changes.