### PR TITLE
Set UTF-8 encoding for Inklecate

### DIFF
--- a/inklecate/CommandLineTool.cs
+++ b/inklecate/CommandLineTool.cs
@@ -45,6 +45,9 @@ namespace Ink
             
 		CommandLineTool(string[] args)
 		{
+            // Set console's output encoding to UTF-8
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+
             if (ProcessArguments (args) == false) {
                 ExitWithUsageInstructions ();
             }


### PR DESCRIPTION
After trying the new *Inky* editor on Windows (it's awesome, despite some quirks!) I've noticed that the player view won't show German umlauts (or any other UTF-8 characters) properly:

![Screenshot](http://i.imgur.com/ZU7XRLH.png)

After poking around a bit, I've noticed that it seems like *Inklecate* never sets any encoding, while *Inky* expects the console input/output to be UTF-8.

After setting the encoding, *Inky* properly shows umlauts and they're still properly shown in console sessions as well (Windows 10).

The change is minimal, but I figured writing a PR would be the same work as creating an issue. Feel free to close this and implement it somewhere else, if you want to.