### PR TITLE
Fix the Windows Visual Studio Project so both Inklecate and ink-engin…

### DIFF
--- a/inklecate/inklecate.csproj
+++ b/inklecate/inklecate.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/inklecate/packages.config
+++ b/inklecate/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Fix Windows Visual Studio so that both Inklecate and ink-engine projects reference the same .NET version of the Newtonsoft JSON dll. In the Visual Studio project, Inklecate was set to use Newtonsoft.JSON.dll for .NET 4.5 which is incompatible with Unity3d. This was causing compilation exceptions to be thrown when using the [ink-unity-integration](https://github.com/inkle/ink-unity-integration) project for Windows. 
Note: After this fixed version is built, its output should then be copied into
the [ink-unity-integration](https://github.com/inkle/ink-unity-integration) project to fix it for Windows users.