### PR TITLE
Clone Element's temporaryVariables

### DIFF
--- a/ink-engine-runtime/CallStack.cs
+++ b/ink-engine-runtime/CallStack.cs
@@ -56,7 +56,7 @@ namespace Ink.Runtime
             public Element Copy()
             {
                 var copy = new Element (this.type, this.currentContainer, this.currentContentIndex, this.inExpressionEvaluation);
-                copy.temporaryVariables = this.temporaryVariables;
+                copy.temporaryVariables = new Dictionary<string,Object>(this.temporaryVariables);
                 return copy;
             }
         }


### PR DESCRIPTION
Clone Element's temporary variables dictionary instead of referencing the same dictionary (leading to variable errors in threads)