### PR TITLE
Fix casting issue in TryCoerce function

### DIFF
--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -1197,7 +1197,7 @@ namespace Ink.Runtime
             if (value == null)
                 return null;
 
-            if (value.GetType () == typeof(T))
+            if (value is T)
                 return (T) value;
 
             if (value is float && typeof(T) == typeof(int)) {


### PR DESCRIPTION
The previous test :
if (value.GetType () == typeof(T))
                return (T) value;
didn't work if "value" type inherited from T

That meant if an external function was supposed to accept any 'object' and was fed with a 'string' it refused it with the error 'Failed to cast String To Object'