### PR TITLE
Fixed float parsing/serialization for systems that use ','

### DIFF
--- a/ink-engine-runtime/SimpleJson.cs
+++ b/ink-engine-runtime/SimpleJson.cs
@@ -185,7 +185,7 @@ namespace Ink.Runtime
 
                 if (isFloat) {
                     float f;
-                    if (float.TryParse (numStr, out f)) {
+                    if (float.TryParse (numStr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out f)) {
                         return f;
                     }
                 } else {
@@ -264,7 +264,7 @@ namespace Ink.Runtime
                 if (obj is int) {
                     _sb.Append ((int)obj);
                 } else if (obj is float) {
-                    string floatStr = obj.ToString ();
+                    string floatStr = ((float)obj).ToString(System.Globalization.CultureInfo.InvariantCulture);
                     _sb.Append (floatStr);
                     if (!floatStr.Contains (".")) _sb.Append (".0");
                 } else if( obj is bool) {

--- a/ink-engine-runtime/Value.cs
+++ b/ink-engine-runtime/Value.cs
@@ -138,7 +138,7 @@ namespace Ink.Runtime
             }
 
             if (newType == ValueType.String) {
-                return new StringValue("" + this.value);
+                return new StringValue("" + this.value.ToString(System.Globalization.CultureInfo.InvariantCulture));
             }
 
             throw new System.Exception ("Unexpected type cast of Value to new ValueType");
@@ -191,7 +191,7 @@ namespace Ink.Runtime
 
             if (newType == ValueType.Float) {
                 float parsedFloat;
-                if (float.TryParse (value, out parsedFloat)) {
+                if (float.TryParse (value, System.Globalization.NumberStyles.Float ,System.Globalization.CultureInfo.InvariantCulture, out parsedFloat)) {
                     return new FloatValue (parsedFloat);
                 } else {
                     return null;

--- a/inklecate/ParsedHierarchy/Number.cs
+++ b/inklecate/ParsedHierarchy/Number.cs
@@ -25,7 +25,11 @@ namespace Ink.Parsed
 
         public override string ToString ()
         {
-            return value.ToString ();
+            if (value is float) {
+                return ((float)value).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            } else {
+                return value.ToString();
+            }
         }
 
         // Equals override necessary in order to check for CONST multiple definition equality

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -90,7 +90,7 @@ Nothing
 { 2 * (5-1) }
 ");
 
-            Assert.AreEqual("36\n2\n3\n2\n2.333333\n8\n8\n", story.ContinueMaximally());
+            Assert.AreEqual("36\n2\n3\n2\n2"+System.Globalization.NumberFormatInfo.CurrentInfo.NumberDecimalSeparator+"333333\n8\n8\n", story.ContinueMaximally());
         }
 
         [Test()]
@@ -327,7 +327,7 @@ two ({num})
 ->->
 ");
 
-            Assert.AreEqual("one (1)\none and a half (1.5)\ntwo (2)\nthree (3)\n", story.ContinueMaximally());
+            Assert.AreEqual("one (1)\none and a half (1"+ System.Globalization.NumberFormatInfo.CurrentInfo.NumberDecimalSeparator+"5)\ntwo (2)\nthree (3)\n", story.ContinueMaximally());
         }
 
         [Test()]
@@ -1996,7 +1996,7 @@ VAR x = 5
 
             story.variablesState["x"] = 8.5f;
             story.ChooseChoiceIndex(0);
-            Assert.AreEqual("8.5\n", story.ContinueMaximally());
+            Assert.AreEqual("8"+ System.Globalization.NumberFormatInfo.CurrentInfo.NumberDecimalSeparator+"5\n", story.ContinueMaximally());
             Assert.AreEqual(8.5f, story.variablesState["x"]);
 
             story.variablesState["x"] = "a string";


### PR DESCRIPTION
Should now consistently use '.' as the separator, no matter the system.