### PR TITLE
Optional commit that fixes issue #186 by enabling dynamic scoping for variables

### DIFF
--- a/ink-engine-runtime/CallStack.cs
+++ b/ink-engine-runtime/CallStack.cs
@@ -291,14 +291,17 @@ namespace Ink.Runtime
                 contextIndex = currentElementIndex+1;
             
             Runtime.Object varValue = null;
+            while (contextIndex > 0)
+            {
+                var contextElement = callStack[contextIndex - 1];
 
-            var contextElement = callStack [contextIndex-1];
-
-            if (contextElement.temporaryVariables.TryGetValue (name, out varValue)) {
-                return varValue;
-            } else {
-                return null;
+                if (contextElement.temporaryVariables.TryGetValue(name, out varValue))
+                {
+                    return varValue;
+                }
+                contextIndex--;
             }
+            return null;
         }
             
         public void SetTemporaryVariable(string name, Runtime.Object value, bool declareNew, int contextIndex = -1)


### PR DESCRIPTION
This might not necessarily be a desireable thing. But it turns the runtime crash from #186 into working just fine at runtime.