### PR TITLE
fixed copypaste error resulting in lacking checks

### DIFF
--- a/inklecate/ParsedHierarchy/DivertTarget.cs
+++ b/inklecate/ParsedHierarchy/DivertTarget.cs
@@ -47,7 +47,7 @@ namespace Ink.Parsed
                         if (!(binaryExprParent.leftExpression is DivertTarget || binaryExprParent.leftExpression is VariableReference)) {
                             badUsage = true;
                         }
-                        if (!(binaryExprParent.leftExpression is DivertTarget || binaryExprParent.leftExpression is VariableReference)) {
+                        if (!(binaryExprParent.rightExpression is DivertTarget || binaryExprParent.rightExpression is VariableReference)) {
                             badUsage = true;
                         }
                     }


### PR DESCRIPTION
```
{-> somewhere == 5}

=== somewhere ===
 a -> DONE
```

caused an exception at runtime and it all to crash.


```
{5 == -> somewhere}

=== somewhere ===
 a -> DONE
```

gets rejected like it should be.

The reason was a copypaste error, which is fixed in this PR - now the first case also gets rejected by the compiler.