### PR TITLE
Improved Divert parsing

### DIFF
--- a/inklecate/InkParser/InkParser_Divert.cs
+++ b/inklecate/InkParser/InkParser_Divert.cs
@@ -100,22 +100,6 @@ namespace Ink
 
         protected List<Object> ParseTunnelContinue()
         {
-            //  -> div -> div ->->   (etc)
-            ParseRule divThenTunnelOnwards = () =>
-            {
-                var x = Parse(DivertIdentifierWithArguments);
-                if (x == null)
-                    return null;
-                var y = Parse(ParseTunnelOnwards);
-                if (y == null)
-                    return null;
-                var ls = new List<Object>();
-                x.isTunnel = true;
-                ls.Add(x);
-                ls.Add(y);
-                return ls;
-            };
-
             //  -> div ->->          -- tunnel then tunnel continue
             // only parsing 1 -> since the other is already parsed for tunnel detection
             ParseRule tunnelOnwards = () =>
@@ -128,6 +112,7 @@ namespace Ink
             };
 
             //  -> div -> div ->     -- tunnel then tunnel
+            //  -> div -> div ->->   (etc) subsumed into this case
             ParseRule furtherTunneling = () =>
             {
                 var x = Parse(DivertIdentifierWithArguments);
@@ -157,7 +142,7 @@ namespace Ink
                 return ret;
             };
             // note: order is important, since furtherTunneling also works for endingDiv, so we need to do most specific first, most general last
-            return (List<Object>)OneOf(tunnelOnwards,divThenTunnelOnwards,furtherTunneling,endingDiv);
+            return (List<Object>)OneOf(tunnelOnwards,furtherTunneling,endingDiv);
         }
         
 

--- a/inklecate/StringParser/StringParser.cs
+++ b/inklecate/StringParser/StringParser.cs
@@ -327,25 +327,6 @@ namespace Ink
             };
         }
 
-        public SpecificParseRule<G> Then<T,G>(SpecificParseRule<T> m, Func<T,SpecificParseRule<G>> f) where T : class where G : class
-        {
-            return () => {
-                var x = Parse(m);
-                return Parse(f(x));
-            };
-        }
-
-        public SpecificParseRule<G> Require<T,G>(SpecificParseRule<T> required, Func<T,SpecificParseRule<G>> f) where T : class where G : class
-        {
-            return () =>
-            {
-                var x = Parse(required);
-                if (x == null)
-                    return null;
-                return Parse(f(x));
-            };
-        }
-
         // Convenience method for creating more readable ParseString rules that can be combined
         // in other structuring rules (like OneOf etc)
         // e.g. OneOf(String("one"), String("two"))

--- a/inklecate/StringParser/StringParser.cs
+++ b/inklecate/StringParser/StringParser.cs
@@ -327,6 +327,25 @@ namespace Ink
             };
         }
 
+        public SpecificParseRule<G> Then<T,G>(SpecificParseRule<T> m, Func<T,SpecificParseRule<G>> f) where T : class where G : class
+        {
+            return () => {
+                var x = Parse(m);
+                return Parse(f(x));
+            };
+        }
+
+        public SpecificParseRule<G> Require<T,G>(SpecificParseRule<T> required, Func<T,SpecificParseRule<G>> f) where T : class where G : class
+        {
+            return () =>
+            {
+                var x = Parse(required);
+                if (x == null)
+                    return null;
+                return Parse(f(x));
+            };
+        }
+
         // Convenience method for creating more readable ParseString rules that can be combined
         // in other structuring rules (like OneOf etc)
         // e.g. OneOf(String("one"), String("two"))


### PR DESCRIPTION
It now properly uses the parser, instead of doing adhoc postprocessing on the parsed result.
As an added benefit, SingleDivert is now a really simple and sensible call instead of more adhoc postprocessing ontop of MultiDivert.

Edit: As a minor note, I just noticed that SingleDivert allowed StartThread to be one of its results, implicitly,  I suspect that that's a later introduced corner case. There are also no tests for this. The current version doesn't include it, but it'd be a trivial change (just adding StartThread to OneOf in SingleDivert)
