### PR TITLE
Convert ink-engine-runtime.csproj to a PCL (Portable Class Library)

### DIFF
--- a/ink-engine-nuget/Inkle.Ink.Engine/Properties/AssemblyInfo.cs
+++ b/ink-engine-nuget/Inkle.Ink.Engine/Properties/AssemblyInfo.cs
@@ -14,6 +14,3 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("992897be-5819-4c0f-b8ad-934f1e581631")]

--- a/ink-engine-nuget/Inkle.Ink.Engine/project.json
+++ b/ink-engine-nuget/Inkle.Ink.Engine/project.json
@@ -2,6 +2,13 @@
   "version": "0.4",
   "title": "Ink Engine",
   "dependencies": {
+    "System.Collections": "4.3.0",
+    "System.Diagnostics.Debug": "4.3.0",
+    "System.Globalization": "4.3.0",
+    "System.IO": "4.3.0",
+    "System.Linq": "4.3.0",
+    "System.Runtime": "4.3.0",
+    "System.Runtime.Extensions": "4.3.0"
   },
   "buildOptions": {
     "compile": {
@@ -23,9 +30,7 @@
   },
   "description": "Runtime engine for the ink scripting language",
   "frameworks": {
-    "net35": {
+    "netstandard1.0": {
     },
-    "net451": {
-    }        
   }
 }

--- a/ink-engine-nuget/Inkle.Ink.Engine/project.json
+++ b/ink-engine-nuget/Inkle.Ink.Engine/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.4",
+  "version": "0.7",
   "title": "Ink Engine",
   "dependencies": {
     "System.Collections": "4.3.0",

--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -133,7 +133,7 @@ namespace Ink.Runtime
             } else if (formatFromFile < inkVersionMinimumCompatible) {
                 throw new System.Exception ("Version of ink used to build story is too old to be loaded by this verison of the engine");
             } else if (formatFromFile != inkVersionCurrent) {
-                Console.WriteLine ("WARNING: Version of ink used to build story doesn't match current version of engine. Non-critical, but recommend synchronising.");
+                System.Diagnostics.Debug.WriteLine ("WARNING: Version of ink used to build story doesn't match current version of engine. Non-critical, but recommend synchronising.");
             }
                 
             var rootToken = rootObject ["root"];

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -276,7 +276,7 @@ namespace Ink.Runtime
         /// Object representation of full JSON state. Usually you should use
         /// LoadJson and ToJson since they serialise directly to string for you.
         /// But it may be useful to get the object representation so that you
-        //// can integrate it into your own serialisation system.
+        /// can integrate it into your own serialisation system.
         /// </summary>
         public Dictionary<string, object> jsonToken
         {

--- a/ink-engine-runtime/ink-engine-runtime.csproj
+++ b/ink-engine-runtime/ink-engine-runtime.csproj
@@ -1,19 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F68D0EE2-1831-4A06-8FFA-CBD0315EFD0E}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ink.Runtime</RootNamespace>
     <AssemblyName>ink-engine-runtime</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <ProductVersion>12.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,7 +20,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\ink-engine-runtime.xml</DocumentationFile>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -33,14 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\ink-engine-runtime.xml</DocumentationFile>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="CallStack.cs" />
     <Compile Include="Container.cs" />
@@ -72,12 +60,5 @@
     <Compile Include="InkList.cs" />
     <Compile Include="ListDefinitionsOrigin.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This makes the DLL usable by a wider range of consumers. I'm using
profile 259 as that seems to have the broadest compatibility (see
http://danrigby.com/2014/04/16/xamarin-pcl-profile-notes/)

With this change, the NuGet package should work out of the box on
new installations of Xamarin, as well as VS 2013 and later.

It should not affect Unity users as they're including the source
directly.