### PR TITLE
Update WritingWithInk.md

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1378,11 +1378,11 @@ Sometimes, a global variable is unwieldy. **ink** provides temporary variables f
 			That night I was colder than I have ever been.
 		}
 
-The value in a temporary variable is thrown away after the story leaves the knot in which it was defined. 
-
-Note that temporary variables MUST be defined within a knot and must be defined at the top of the knot or assigning to them will not behave correctly.
+The value in a temporary variable is thrown away after the story leaves the knot in which it was defined.
 
 TODO: check this is actually true
+
+Note that temporary variables MUST be defined within a knot and must be defined at the top of the knot or assigning to them will not behave correctly.
 
 ### Knots and stitches can take parameters
 

--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1380,6 +1380,8 @@ Sometimes, a global variable is unwieldy. **ink** provides temporary variables f
 
 The value in a temporary variable is thrown away after the story leaves the knot in which it was defined. 
 
+Note that temporary variables MUST be defined within a knot and must be defined at the top of the knot or assigning to them will not behave correctly.
+
 TODO: check this is actually true
 
 ### Knots and stitches can take parameters


### PR DESCRIPTION
I ran into an issue within a scene I was writing in Inky where my temp variables were seemingly not being assigned to, but I could reference them for conditional logic calculations. I discovered that the issue was that the scene was not placed within a knot at all. I had merely started writing Ink at the top of the file with no knot containing it. Once I moved all my text into a top-level knot AND moved the temp variable declaration to the top of the knot – previously it was declared inline within a weave – everything worked perfectly.