### PR TITLE
Need to copy storyState._originalCallstack

### DIFF
--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -256,6 +256,7 @@ namespace Ink.Runtime
             }
 
             copy.callStack = new CallStack (callStack);
+            copy._originalCallstack = _originalCallstack;
 
             copy.variablesState = new VariablesState (copy.callStack, story.listDefinitions);
             copy.variablesState.CopyFrom (variablesState);

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -256,7 +256,7 @@ namespace Ink.Runtime
             }
 
             copy.callStack = new CallStack (callStack);
-            copy._originalCallstack = _originalCallstack;
+            copy._originalCallstack = new CallStack(_originalCallstack);
 
             copy.variablesState = new VariablesState (copy.callStack, story.listDefinitions);
             copy.variablesState.CopyFrom (variablesState);

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -262,6 +262,7 @@ namespace Ink.Runtime
             copy.variablesState.CopyFrom (variablesState);
 
             copy.evaluationStack.AddRange (evaluationStack);
+            copy._originalEvaluationStackHeight = _originalEvaluationStackHeight;
 
             if (divertedTargetObject != null)
                 copy.divertedTargetObject = divertedTargetObject;


### PR DESCRIPTION
Not sure how this has not been an issue before, but it's recently started causing errors in our external function calls - perhaps they just hit a certain level of complexity? The issue seen in the inkjs prototype is that _originalCallstack is null by the time the external function finishes, when it then attempts to put that state back in again. The solution here fixes the issue in inkjs but I've not repo'd the issue in "real" ink.