### PR TITLE
More tmLanguage fixes

### DIFF
--- a/Sublime3Syntax/ink.YAML-tmLanguage
+++ b/Sublime3Syntax/ink.YAML-tmLanguage
@@ -69,7 +69,20 @@ repository:
       '2': { name: comment.todo.TODO }
     end: $\n?
     name: comment.todo
-
+  include:
+    begin: ^\s*((INCLUDE)\s*(\S*))\s*
+    beginCaptures:
+      '1': {name: meta.include}
+      '2': {name: keyword.control.include}
+      '3': {name: string.other }
+    end: $\n?
+  external:
+    begin: ^\s*((EXTERNAL)\s*([\w_0-9]*\(\)))\s*
+    beginCaptures:
+      '1': {name: meta.external}
+      '2': {name: keyword.control.external}
+      '3': {name: support.function }
+    end: $\n?
   globalVAR:
     begin: ^\s*((VAR|CONST)\s*(\w+))\s*
     beginCaptures:
@@ -209,6 +222,8 @@ repository:
 
   statements:
     patterns:
+      - {include: '#include'}
+      - {include: '#external'}
       - {include: '#comments'}
       - {include: '#TODO'}
       - {include: '#globalVAR'}

--- a/Sublime3Syntax/ink.YAML-tmLanguage
+++ b/Sublime3Syntax/ink.YAML-tmLanguage
@@ -23,7 +23,7 @@ patterns:
 - match: ^\s*(=)\s*(\w+)\s*(\([^)\n]*\))?\s*$
   captures:
     '1': {name: markup.punctuation}
-    '2': {name: entity.name.knot}
+    '2': {name: entity.name.stitch}
     '3': {name: variable.parameter}
   name: meta.stitch.declaration
 

--- a/Sublime3Syntax/ink.YAML-tmLanguage
+++ b/Sublime3Syntax/ink.YAML-tmLanguage
@@ -23,10 +23,8 @@ patterns:
 - match: ^\s*(=)\s*(\w+)\s*(\([^)\n]*\))?\s*$
   captures:
     '1': {name: markup.punctuation}
-    '2': {name: keyword.function}
-    '3': {name: entity.name.knot}
-    '4': {name: variable.parameter}
-    '5': {name: markup.punctuation}
+    '2': {name: entity.name.knot}
+    '3': {name: variable.parameter}
   name: meta.stitch.declaration
 
 

--- a/Sublime3Syntax/ink.tmLanguage
+++ b/Sublime3Syntax/ink.tmLanguage
@@ -66,7 +66,7 @@
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>entity.name.knot</string>
+            <string>entity.name.stitch</string>
           </dict>
           <key>3</key>
           <dict>

--- a/Sublime3Syntax/ink.tmLanguage
+++ b/Sublime3Syntax/ink.tmLanguage
@@ -66,22 +66,12 @@
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>keyword.function</string>
+            <string>entity.name.knot</string>
           </dict>
           <key>3</key>
           <dict>
             <key>name</key>
-            <string>entity.name.knot</string>
-          </dict>
-          <key>4</key>
-          <dict>
-            <key>name</key>
             <string>variable.parameter</string>
-          </dict>
-          <key>5</key>
-          <dict>
-            <key>name</key>
-            <string>markup.punctuation</string>
           </dict>
         </dict>
         <key>name</key>

--- a/Sublime3Syntax/ink.tmLanguage
+++ b/Sublime3Syntax/ink.tmLanguage
@@ -200,6 +200,56 @@
         <key>name</key>
         <string>comment.todo</string>
       </dict>
+      <key>include</key>
+      <dict>
+        <key>begin</key>
+        <string>^\s*((INCLUDE)\s*(\S*))\s*</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>meta.include</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.include</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>string.other</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>$\n?</string>
+      </dict>
+      <key>external</key>
+      <dict>
+        <key>begin</key>
+        <string>^\s*((EXTERNAL)\s*([\w_0-9]*\(\)))\s*</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>meta.external</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.external</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>support.function</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>$\n?</string>
+      </dict>
       <key>globalVAR</key>
       <dict>
         <key>begin</key>
@@ -575,6 +625,14 @@
       <dict>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#include</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#external</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#comments</string>


### PR DESCRIPTION
- Added support for `INCLUDE` and `EXTERNAL` like `VAR` and `CONST` are already supported.
- Fixed stitch declarations having wrong captures copied directly from knot declarations (even though knots can be functions while stitches can't, causing stitch names to be scoped as `keyword.function`.