### PR TITLE
Support for escaped square-brackets in choice-only content.

### DIFF
--- a/Sublime3Syntax/ink.YAML-tmLanguage
+++ b/Sublime3Syntax/ink.YAML-tmLanguage
@@ -100,7 +100,7 @@ repository:
     name: choice
     patterns:
       - {include: '#comments'}
-      - match: (\[)([^\]]*)(\])
+      - match: (\[)((?:[^\]]|\\\[|\])*)(\])
         captures:
           '1': {name: keyword.operator.weaveBracket}
           '2': {name: string.content}

--- a/Sublime3Syntax/ink.tmLanguage
+++ b/Sublime3Syntax/ink.tmLanguage
@@ -301,7 +301,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(\[)([^\]]*)(\])</string>
+            <string>(\[)((?:[^\]]|\\\[|\])*)(\])</string>
             <key>captures</key>
             <dict>
               <key>1</key>


### PR DESCRIPTION
The Ink engine supports choices that look like this :
```
* [ \[bracketted\] ]
```
The .tmLanguage file didn't support that and stopped at the first `]`

I just edited the two files, and didn't proceed to the whole process described in the readme since I don't use ST or mac.
I tested it in vscode though and it works. Shouldn't break anything either.