### PR TITLE
Features/3 5 runtime

### DIFF
--- a/compiler/InkParser/CommentEliminator.cs
+++ b/compiler/InkParser/CommentEliminator.cs
@@ -19,7 +19,7 @@ namespace Ink
             var stringList = Interleave<string>(Optional (CommentsAndNewlines), Optional(MainInk));
 
             if (stringList != null) {
-                return string.Join("", stringList);
+                return string.Join("", stringList.ToArray());
             } else {
                 return null;
             }
@@ -35,7 +35,7 @@ namespace Ink
             var newlines = Interleave<string> (Optional (ParseNewline), Optional (ParseSingleComment));
 
             if (newlines != null) {
-                return string.Join ("", newlines);
+                return string.Join ("", newlines.ToArray());
             } else {
                 return null;
             }

--- a/compiler/InkParser/InkParser_Content.cs
+++ b/compiler/InkParser/InkParser_Content.cs
@@ -38,7 +38,9 @@ namespace Ink
                     result = tags.Cast<Parsed.Object> ().ToList ();
                     onlyTags = true;
                 } else {
-                    result.AddRange (tags);
+                    foreach (var tag in tags) {
+                        result.Add(tag);
+                    }
                 }
             }
 

--- a/compiler/InkStringConversionExtensions.cs
+++ b/compiler/InkStringConversionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Ink
+{
+    internal static class InkStringConversionExtensions
+    {
+        public static string[] ToStringsArray<T>(this List<T> list) {
+            int count = list.Count;
+            var strings = new string[count];
+
+            for(int i = 0; i < count; i++) {
+                strings[i] = list[i].ToString();
+            }
+
+            return strings;
+        }
+    }
+}

--- a/compiler/ParsedHierarchy/ContentList.cs
+++ b/compiler/ParsedHierarchy/ContentList.cs
@@ -69,7 +69,7 @@ namespace Ink.Parsed
         {
             var sb = new StringBuilder ();
             sb.Append ("ContentList(");
-            sb.Append(string.Join (", ", content));
+            sb.Append(string.Join (", ", content.ToStringsArray()));
             sb.Append (")");
             return sb.ToString ();
         }

--- a/compiler/ParsedHierarchy/FunctionCall.cs
+++ b/compiler/ParsedHierarchy/FunctionCall.cs
@@ -233,7 +233,7 @@ namespace Ink.Parsed
 
         public override string ToString ()
         {
-            var strArgs = string.Join (", ", arguments);
+            var strArgs = string.Join (", ", arguments.ToStringsArray());
             return string.Format ("{0}({1})", name, strArgs);
         }
             

--- a/compiler/ParsedHierarchy/Object.cs
+++ b/compiler/ParsedHierarchy/Object.cs
@@ -177,7 +177,7 @@ namespace Ink.Parsed
 
                 var scopeSB = new StringBuilder ();
                 if (locationNames.Count > 0) {
-                    var locationsListStr = string.Join (", ", locationNames);
+                    var locationsListStr = string.Join (", ", locationNames.ToArray());
                     scopeSB.Append (locationsListStr);
                     scopeSB.Append (" and ");
                 }

--- a/compiler/ParsedHierarchy/Path.cs
+++ b/compiler/ParsedHierarchy/Path.cs
@@ -38,7 +38,7 @@ namespace Ink.Parsed
 
         public string dotSeparatedComponents {
             get {
-                return string.Join (".", _components);
+                return string.Join (".", _components.ToArray());
             }
         }
 

--- a/compiler/ParsedHierarchy/VariableReference.cs
+++ b/compiler/ParsedHierarchy/VariableReference.cs
@@ -10,7 +10,7 @@ namespace Ink.Parsed
         // - List names are dot separated: listName.itemName (or just itemName)
         public string name { 
             get {
-                return string.Join (".", path);
+                return string.Join (".", path.ToArray());
             } 
         }
         
@@ -111,7 +111,7 @@ namespace Ink.Parsed
             if (path.Count > 1) {
                 var errorMsg = "Could not find target for read count: " + parsedPath;
                 if (path.Count <= 2)
-                    errorMsg += ", or couldn't find list item with the name " + string.Join (",", path);
+                    errorMsg += ", or couldn't find list item with the name " + string.Join (",", path.ToArray());
                 Error (errorMsg);
                 return;
             }
@@ -123,7 +123,7 @@ namespace Ink.Parsed
 
         public override string ToString ()
         {
-            return string.Join(".", path);
+            return string.Join(".", path.ToArray());
         }
 
         Runtime.VariableReference _runtimeVarRef;

--- a/compiler/StringParser/StringParser.cs
+++ b/compiler/StringParser/StringParser.cs
@@ -110,7 +110,7 @@ namespace Ink
             object result = ParseObject(rule);
 			if (result == null) {
 				if (message == null) {
-                    message = rule.GetMethodInfo().Name;
+                    message = rule.Method.Name;
 				}
 
                 string butSaw;

--- a/compiler/ink_compiler.csproj
+++ b/compiler/ink_compiler.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -95,6 +95,9 @@
       <Project>{F68D0EE2-1831-4A06-8FFA-CBD0315EFD0E}</Project>
       <Name>ink-engine-runtime</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/compiler/ink_compiler.csproj
+++ b/compiler/ink_compiler.csproj
@@ -25,6 +25,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="InkStringConversionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParsedHierarchy\AuthorWarning.cs" />
     <Compile Include="ParsedHierarchy\Choice.cs" />

--- a/compiler/ink_compiler.csproj
+++ b/compiler/ink_compiler.csproj
@@ -4,12 +4,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{52E3F3D0-2702-44E5-82F5-783B82647CA5}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Ink</RootNamespace>
     <AssemblyName>ink_compiler</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,5 +96,5 @@
       <Name>ink-engine-runtime</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ink-engine-runtime/ink-engine-runtime.csproj
+++ b/ink-engine-runtime/ink-engine-runtime.csproj
@@ -4,12 +4,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F68D0EE2-1831-4A06-8FFA-CBD0315EFD0E}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Ink.Runtime</RootNamespace>
     <AssemblyName>ink-engine-runtime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -63,5 +61,5 @@
     <Compile Include="Pointer.cs" />
     <Compile Include="SearchResult.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ink-engine-runtime/ink-engine-runtime.csproj
+++ b/ink-engine-runtime/ink-engine-runtime.csproj
@@ -61,5 +61,8 @@
     <Compile Include="Pointer.cs" />
     <Compile Include="SearchResult.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
After discussions in the previous pull request (see https://github.com/inkle/ink/pull/438) we have decided to make minimal changes to the compiler API (without too much intrusion which was apparent in the previous PR).

I have also went the least "destructive" path possible - hand changing Project XMLs (not creating new ones in Visual Studio) to keep them as close to original as possible.

For an "in-field" test example here's our Unity setup:
![image](https://user-images.githubusercontent.com/2943071/41349742-8dc024d4-6f19-11e8-9477-317da5951cf9.png)

Currently, ink_compiler is only included in the Editor builds, while runtime is built along with the game. We have a lot of custom Editor Compilation code that uses the ink_compiler.dll directly. It's also possible to include the compiler along with the game build and compile Ink at runtime (on any platform, including WebGL).

Also, I have tried opening the solution in MonoDevelop and Xamarin on Mac and it opens and builds nicely:
![image](https://user-images.githubusercontent.com/2943071/41349311-2d858948-6f18-11e8-8460-0abbabec64dc.png)
![image](https://user-images.githubusercontent.com/2943071/41349462-8df8f9d6-6f18-11e8-86ac-7f806fadae2e.png)
