### PR TITLE
Explicitly set search path for mkbundle in build_release.command

### DIFF
--- a/build_release.command
+++ b/build_release.command
@@ -21,7 +21,7 @@ export CC="cc -arch i386 -framework CoreFoundation -lobjc -liconv"
 
 # "Bundles in addition support a –static flag. The –static flag causes mkbundle to generate a static executable that statically links the Mono runtime. Be advised that this option will trigger the LGPL requirement that you still distribute the independent pieces to your user so he can manually upgrade his Mono runtime if he chooses to do so. Alternatively, you can obtain a proprietary license of Mono by contacting Xamarin."
 # http://www.mono-project.com/archived/guiderunning_mono_applications/
-mkbundle ./inklecate/bin/Release/inklecate.exe ./inklecate/bin/Release/ink-engine-runtime.dll ./inklecate/bin/Release/ink_compiler.dll --deps --static --sdk /Library/Frameworks/Mono.framework/Versions/Current -o ./ReleaseBinary/inklecate
+mkbundle ./inklecate/bin/Release/inklecate.exe ./inklecate/bin/Release/ink-engine-runtime.dll ./inklecate/bin/Release/ink_compiler.dll --deps --static --sdk /Library/Frameworks/Mono.framework/Versions/Current -o ./ReleaseBinary/inklecate -L ./inklecate/bin/Release
 zip --junk-paths ReleaseBinary/inklecate_mac.zip ReleaseBinary/inklecate ink-engine-runtime/bin/Release/ink-engine-runtime.dll inklecate/bin/Release/ink_compiler.dll
 
 rm ReleaseBinary/inklecate


### PR DESCRIPTION
When I run:
```
$ bash build_release.command
```
mkbundle seems to not search` inklecate/bin/Release` on my machine which leads to the following error message:
```
ERROR: Unable to load assembly `ink_compiler' referenced by `/Users/blah/inklecate/bin/Release/inklecate.exe'
```
Despite `ink_compiler.dll` sitting right next to `inklecate.exe` in `inklecate/bin/Release`. This can be fixed by explicitly adding `inklecate/bin/Release` to the search path using -L.

I guess this works normally so I'm not sure why this is the case for me but I thought I would upload a patch anyway in case it is helpful for others :)