### PR TITLE
[stack] check for empty stacks before returning the head

### DIFF
--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -778,14 +778,24 @@ namespace Ink.Runtime
 
         internal Runtime.Object PopEvaluationStack()
         {
-            var obj = evaluationStack [evaluationStack.Count - 1];
-            evaluationStack.RemoveAt (evaluationStack.Count - 1);
-            return obj;
+            if (evaluationStack.Count > 0) {
+              var obj = evaluationStack [evaluationStack.Count - 1];
+              evaluationStack.RemoveAt (evaluationStack.Count - 1);
+              return obj;
+            } else {
+              Error ("Tried to pop from empty evaluation stack. "
+              + "Maybe you used a divert to a knot as a function call?");
+              return null;
+            }
         }
 
         internal Runtime.Object PeekEvaluationStack()
         {
-            return evaluationStack [evaluationStack.Count - 1];
+            if (evaluationStack.Count > 0) {
+              return evaluationStack [evaluationStack.Count - 1];
+            } else {
+              return null;
+            }
         }
 
         internal List<Runtime.Object> PopEvaluationStack(int numberOfObjects)


### PR DESCRIPTION
As mentioned in #296, calling divert targets as functions can lead to knots being called as functions, which leads to a value being popped when none was pushed.

This PR adds a check for empty stacks before peeking or peeping.

There is no guarantee that the error message will be on the same line than the knot call, but it's better than straight crashing.