### PR TITLE
Replace non-breaking spaces with normal spaces in md files

### DIFF
--- a/Documentation/ArchitectureAndDevOverview.md
+++ b/Documentation/ArchitectureAndDevOverview.md
@@ -10,7 +10,7 @@ The ink pipeline broadly consists of 3 stages:
 
 The following is a fairly brief tour of these 3 stages, hopefully enough to give you a foundation for exploring the codebase yourself.
 
-## Ink parser
+## Ink parser
 
 The parser takes a root ink file (which may reference other ink files), and constructs a hierarchy of `Parsed.Object` objects that closely resemble the structure within the original ink files, as closely as possible to how it was written.
 
@@ -33,7 +33,7 @@ Crucially however, parse rules are wrapped in either `ParseObject(rule)` or `Par
         
 If a rule isn't wrapped in a `Parse` method, then it's an indication that rewinding definitely isn't strictly necessary within the scope, for example if a sub-rule is both optional and atomic. Or, when success and failure of the rule is handled manually.
         
-## StringParser structuring
+## StringParser structuring
 
 The base class `StringParser` contains a number of helper methods to help with parsing.
 
@@ -95,7 +95,7 @@ Each `Parsed.Object` can implement:
         runtimeDivert.targetPath = targetContent.runtimePath;
     }
 
-## Runtime ink engine
+## Runtime ink engine
 
 As mentioned above, the runtime code is built out of smaller, simpler, objects compared to the ink as it's parsed directly.
 
@@ -134,7 +134,7 @@ Some important and useful features of the main runtime engine in `Story.cs`:
  * `Step()` iterates through a single element of content, and returns `false` if it runs out of content.
  * `PerformLogicAndFlowControl(contentObject, out endFlow)` is called from `Step`, and handles the majority of the non-content objects such Diverts, Control Commands, etc.
 
-### Callstack and threads
+### Callstack and threads
 
 TODO
 

--- a/Sublime3Syntax/README.md
+++ b/Sublime3Syntax/README.md
@@ -20,7 +20,7 @@
 
 ### Other files
 
- * `ink.YAML-tmLanguage`: This is the main source file for the syntax
+ * `ink.YAML-tmLanguage`: This is the main source file for the syntax
  * `LiveWatchAndInstallOnEdit.command` - when continuously editing the above the files, you can run this script so that it installs them automatically as you save changes to them (Mac only).
 
 (Note: Unfortunately we can't use the alternative `.sublime-syntax` ([documentation here](https://www.sublimetext.com/docs/3/syntax.html)) just yet since it's not available for non-dev builds of Sublime Text 3 yet.)


### PR DESCRIPTION
They were causing GitHub markdown rendering to look wrong for a couple of headings:

Before:
<img width="533" alt="Screenshot 2019-06-23 at 20 01 14" src="https://user-images.githubusercontent.com/351085/59980723-b3572300-95f1-11e9-86b2-b6bb4ac15962.png">

After:
<img width="528" alt="Screenshot 2019-06-23 at 20 00 51" src="https://user-images.githubusercontent.com/351085/59980726-b7834080-95f1-11e9-83fc-7a634c8de2b0.png">


