### PR TITLE
Ensure keys are removed from _variableObservers if they are empty.

### DIFF
--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -2057,6 +2057,9 @@ namespace Ink.Runtime
                 if (_variableObservers.ContainsKey (specificVariableName)) {
                     if( observer != null) {
                         _variableObservers [specificVariableName] -= observer;
+			if (_variableObservers[specificVariableName] == null) {
+			    _variableObservers.Remove(specificVariableName);
+			}
                     }
                     else {
                         _variableObservers.Remove(specificVariableName);
@@ -2069,6 +2072,9 @@ namespace Ink.Runtime
                 var keys = new List<string>(_variableObservers.Keys);
                 foreach (var varName in keys) {
                     _variableObservers[varName] -= observer;
+		    if (_variableObservers[varName] == null) {
+		    	_variableObservers.Remove(varName);
+		    }
                 }
             }
         }


### PR DESCRIPTION
Fixing Issue 533 - https://github.com/inkle/ink/issues/533

When removing variableObservers, the dictionary holding them may still hold a key with `null` as a value. This will cause an Exception to be thrown if that variable is changed again. This fix ensures empty keys are completely removed from that dictionary. 