### PR TITLE
Documentation: Remove knot from Tags section

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -60,8 +60,7 @@ Text content from the game will appear 'as is' when the engine runs. However, it
 
 **ink** provides a simple system for tagging lines of content, with hashtags. 
 
-	=== content 
-		A line of normal game-text. # colour it blue
+	A line of normal game-text. # colour it blue
 
 These don't show up in the main text flow, but can be read off by the game and used as you see fit. See [RunningYourInk](https://github.com/inkle/ink/blob/master/Documentation/RunningYourInk.md#marking-up-your-ink-content-with-tags) for more information.
 


### PR DESCRIPTION
This is a very minor fix. Knots aren't introduced until subsection 3) Knots.