### PR TITLE
Keep track of character indices in DebugMetadata (LSP 1/2)

### DIFF
--- a/compiler/InkParser/InkParser.cs
+++ b/compiler/InkParser/InkParser.cs
@@ -4,20 +4,20 @@ using System.IO;
 
 namespace Ink
 {
-	public partial class InkParser : StringParser
-	{
-        public InkParser(string str, string filenameForMetadata = null, Ink.ErrorHandler externalErrorHandler = null, IFileHandler fileHandler = null) 
-            : this(str, filenameForMetadata, externalErrorHandler, null, fileHandler) 
+    public partial class InkParser : StringParser
+    {
+        public InkParser(string str, string filenameForMetadata = null, Ink.ErrorHandler externalErrorHandler = null, IFileHandler fileHandler = null)
+            : this(str, filenameForMetadata, externalErrorHandler, null, fileHandler)
         {  }
 
-        InkParser(string str, string inkFilename = null, Ink.ErrorHandler externalErrorHandler = null, InkParser rootParser = null, IFileHandler fileHandler = null) : base(str) { 
+        InkParser(string str, string inkFilename = null, Ink.ErrorHandler externalErrorHandler = null, InkParser rootParser = null, IFileHandler fileHandler = null) : base(str) {
             _filename = inkFilename;
-			RegisterExpressionOperators ();
+            RegisterExpressionOperators ();
             GenerateStatementLevelRules ();
 
             // Built in handler for all standard parse errors and warnings
             this.errorHandler = OnStringParserError;
-            
+
             // The above parse errors are then formatted as strings and passed
             // to the Ink.ErrorHandler, or it throws an exception
             _externalErrorHandler = externalErrorHandler;
@@ -38,7 +38,7 @@ namespace Ink
                 _rootParser = rootParser;
             }
 
-		}
+        }
 
         // Main entry point
         public Parsed.Story Parse()
@@ -101,6 +101,8 @@ namespace Ink
                 var md = new Runtime.DebugMetadata ();
                 md.startLineNumber = stateAtStart.lineIndex + 1;
                 md.endLineNumber = stateAtEnd.lineIndex + 1;
+                md.startCharacterNumber = stateAtStart.characterInLineIndex + 1;
+                md.endCharacterNumber = stateAtEnd.characterInLineIndex + 1;
                 md.fileName = _filename;
                 parsedObj.debugMetadata = md;
                 return;
@@ -114,18 +116,20 @@ namespace Ink
                         var md = new Runtime.DebugMetadata ();
                         md.startLineNumber = stateAtStart.lineIndex + 1;
                         md.endLineNumber = stateAtEnd.lineIndex + 1;
+                        md.startCharacterNumber = stateAtStart.characterInLineIndex + 1;
+                        md.endCharacterNumber = stateAtEnd.characterInLineIndex + 1;
                         md.fileName = _filename;
                         parsedListObj.debugMetadata = md;
                     }
                 }
             }
         }
-            
+
         protected bool parsingStringExpression
         {
             get {
                 return GetFlag ((uint)CustomFlags.ParsingString);
-            } 
+            }
             set {
                 SetFlag ((uint)CustomFlags.ParsingString, value);
             }
@@ -158,6 +162,6 @@ namespace Ink
         Ink.ErrorHandler _externalErrorHandler;
 
         string _filename;
-	}
+    }
 }
 

--- a/compiler/StringParser/StringParserState.cs
+++ b/compiler/StringParser/StringParserState.cs
@@ -3,15 +3,20 @@ namespace Ink
 {
 	public class StringParserState
 	{
-		public int lineIndex { 
-			get { return currentElement.lineIndex; } 
-			set { currentElement.lineIndex = value; } 
+		public int lineIndex {
+			get { return currentElement.lineIndex; }
+			set { currentElement.lineIndex = value; }
 		}
 
-		public int characterIndex { 
-			get { return currentElement.characterIndex; } 
-			set { currentElement.characterIndex = value; } 
+		public int characterIndex {
+			get { return currentElement.characterIndex; }
+			set { currentElement.characterIndex = value; }
 		}
+
+        public int characterInLineIndex {
+            get { return currentElement.characterInLineIndex; }
+            set { currentElement.characterInLineIndex = value; }
+        }
 
         public uint customFlags {
             get { return currentElement.customFlags; }
@@ -29,9 +34,10 @@ namespace Ink
                 return _numElements;
             }
         }
-					
+
 		public class Element {
 			public int characterIndex;
+            public int characterInLineIndex;
 			public int lineIndex;
             public bool reportedErrorInScope;
             public int uniqueId;
@@ -46,6 +52,7 @@ namespace Ink
                 _uniqueIdCounter++;
                 this.uniqueId = _uniqueIdCounter;
                 this.characterIndex = fromElement.characterIndex;
+                this.characterInLineIndex = fromElement.characterInLineIndex;
                 this.lineIndex = fromElement.lineIndex;
                 this.customFlags = fromElement.customFlags;
                 this.reportedErrorInScope = false;
@@ -60,6 +67,7 @@ namespace Ink
             public void SquashFrom(Element fromElement)
             {
                 this.characterIndex = fromElement.characterIndex;
+                this.characterInLineIndex = fromElement.characterInLineIndex;
                 this.lineIndex = fromElement.lineIndex;
                 this.reportedErrorInScope = fromElement.reportedErrorInScope;
             }
@@ -137,7 +145,7 @@ namespace Ink
             var lastEl = _stack [_numElements - 1];
 
             penultimateEl.SquashFrom (lastEl);
-				
+
             _numElements--;
 		}
 
@@ -147,7 +155,7 @@ namespace Ink
                 el.reportedErrorInScope = true;
             }
         }
-            
+
 		protected Element currentElement
 		{
 			get {

--- a/ink-engine-runtime/DebugMetadata.cs
+++ b/ink-engine-runtime/DebugMetadata.cs
@@ -4,6 +4,8 @@
 	{
 		public int startLineNumber = 0;
         public int endLineNumber = 0;
+        public int startCharacterNumber = 0;
+        public int endCharacterNumber = 0;
         public string fileName = null;
         public string sourceName = null;
 


### PR DESCRIPTION
Title says all. I'm not too sure about the wording: `characterInLineIndex` sounds a bit weird, but `characterIndex` was already taken.

Sorry about the noise, the editor removed trailing whitespaces and converted tabs to spaces in `InkParser.cs`. (I can revert those changes, but I think Joe mentioned they're okay on another PR.)

Thanks for having a look!