### PR TITLE
Documentation: Update the README with correct dependencies for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To keep up to date with the latest news about ink [sign up for the mailing list]
     **Linux:** `mono inklecate.exe -p myStory.ink`
     
     * To run on Linux, you need the Mono runtime and the Mono System.Core library (for CLI 4.0). If you have access to the debian repository, you can install these using: <br>
-    `sudo apt-get install mono-runtime libmono-system-core4.0-cil`
+    `sudo apt install mono-complete`
 
     The `-p` option uses play mode so that you can see the result immediately. If you want to get a compiled `.json` file, just remove the `-p` option from the examples above.
     


### PR DESCRIPTION
Right now, if you run inklecate on Ubuntu according to the instructions in the readme, you'll get an unhelpful exception due to a missing dependency. 

`
Unhandled Exception:
System.IO.FileNotFoundException: Could not load file or assembly or one of its dependencies.
File name: 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
at Ink.CommandLineTool.Main (System.String[] args) [0x00000] in 
<22aa2ecb8c6b41f494a352131f83f312>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.IO.FileNotFoundException: Could not load file or 
assembly or one of its dependencies.
File name: 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
at Ink.CommandLineTool.Main (System.String[] args) [0x00000] in 
<22aa2ecb8c6b41f494a352131f83f312>:0`

The workaround is to install mono-complete (as suggested in the comments on several open issues), but updating the readme will save people a bit of digging. :) Fixes #241 #430 and #487.
