### PR TITLE
Triggers Observers after Loading StoryState

### DIFF
--- a/ink-engine-runtime/VariablesState.cs
+++ b/ink-engine-runtime/VariablesState.cs
@@ -137,7 +137,7 @@ namespace Ink.Runtime
             foreach (var varVal in _defaultGlobalVariables) {
                 object loadedToken;
                 if( jToken.TryGetValue(varVal.Key, out loadedToken) ) {
-                    _globalVariables[varVal.Key] = Json.JTokenToRuntimeObject(loadedToken);
+                    SetGlobal(varVal.Key, Json.JTokenToRuntimeObject(loadedToken));
                 } else {
                     _globalVariables[varVal.Key] = varVal.Value;
                 }


### PR DESCRIPTION
When using SetJsonToken to set globalvariables, it does not trigger variable observers.
Using SetGlobal function will allow that.