### PR TITLE
update for wack_a_mole example

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -2251,7 +2251,8 @@ But what if we add a microwave as well? We might want start generalising our fun
 	*	{kettleState == cold} [Turn on kettle] 
 		{boilSomething(kettleState, "kettle")}
 	*	{potState == cold} [Light stove] 
-		{boilSomething(potState, "pot")}		*	{microwaveState == cold} [Turn on microwave] 
+		{boilSomething(potState, "pot")}		
+	*	{microwaveState == cold} [Turn on microwave] 
 		{boilSomething(microwaveState, "microwave")}
 
 or even... 


### PR DESCRIPTION
If you used that example as written, Inky would give a warning to use "* ->" syntax for a fallback choice. Rewritten to not give an error.