### PR TITLE
fix: fixed getting tags from the knots that accepts parameters

### DIFF
--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -2388,7 +2388,7 @@ namespace Ink.Runtime
 
             // Any initial tag objects count as the "main tags" associated with that story/knot/stitch
             List<string> tags = null;
-            foreach (var c in flowContainer.content) {
+            foreach (var c in flowContainer.content.Where(item => item is Runtime.Tag)) {
                 var tag = c as Runtime.Tag;
                 if (tag) {
                     if (tags == null) tags = new List<string> ();


### PR DESCRIPTION
This fixes the issue mentioned in [#632 ](https://github.com/inkle/ink/issues/632 ). When knots accept parameters the flowContainer.content has them inside thus breaking the foreach loop.

