### PR TITLE
Added some parallel flow utility functions

### DIFF
--- a/Documentation/RunningYourInk.md
+++ b/Documentation/RunningYourInk.md
@@ -302,6 +302,10 @@ The API is relatively simple:
 - `story.SwitchFlow("Your flow name")` - create a new Flow context, or switch to an existing one. The name can be anything you like, though you may choose to use the same name as an entry knot that you would go on to choose with `story.ChoosePathString("knotName")`.
 - `story.SwitchToDefaultFlow()` - before you start switching Flows there's an implicit default Flow. To return to it, call this method.
 - `story.RemoveFlow("Your flow name")` - destroy a previously created Flow. If the Flow is already active, it returns to the default flow.
+- `story.aliveFlowNames` - the names of currently alive flows. A flow is alive if it's previously been switched to and hasn't been destroyed. Does not include default flow.
+- `story.currentFlowIsDefaultFlow` - true if the default flow is currently active. By definition, will also return true if not using flow functionality.
+- `story.currentFlowName` — a string containing the name of the currently active flow. May contain internal identifier for default flow, so use `currentFlowIsDefault` to check first.
+)
 
 ## Working with LISTs
 

--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -90,9 +90,20 @@ namespace Ink.Runtime
         public List<string> currentWarnings { get { return state.currentWarnings; } }
 
         /// <summary>
-        /// The current flow name if using multi-flow funtionality - see SwitchFlow
+        /// The current flow name if using multi-flow functionality - see SwitchFlow
         /// </summary>
         public string currentFlowName => state.currentFlowName;
+
+        /// <summary>
+        /// Is the default flow currently active? By definition, will also return true if not using multi-flow functionality - see SwitchFlow
+        /// </summary>
+        public bool currentFlowIsDefaultFlow { get { return state.currentFlowIsDefaultFlow; } }
+
+        /// <summary>
+        /// Names of currently alive flows (not including the default flow)
+        /// </summary>
+
+        public List<string> aliveFlowNames { get { return state.aliveFlowNames; } }
 
         /// <summary>
         /// Whether the currentErrors list contains any errors.

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -351,6 +351,36 @@ namespace Ink.Runtime
             }
         }
 
+        public bool currentFlowIsDefaultFlow {
+            get {
+                return _currentFlow.name == kDefaultFlowName;
+            }
+        }
+
+        public List<string> aliveFlowNames {
+            get {
+
+                if( _aliveFlowNamesDirty ) {
+					_aliveFlowNames = new List<string>();
+
+                    if (_namedFlows != null)
+                    {
+                        foreach (string flowName in _namedFlows.Keys) {
+                            if (flowName != kDefaultFlowName) {
+                                _aliveFlowNames.Add(flowName);
+                            }
+                        }
+                    }
+
+					_aliveFlowNamesDirty = false;
+				}
+
+				return _aliveFlowNames;
+            }
+        }
+
+        List<string> _aliveFlowNames;
+
         public bool inExpressionEvaluation {
             get {
                 return callStack.currentElement.inExpressionEvaluation;
@@ -367,6 +397,7 @@ namespace Ink.Runtime
             _currentFlow = new Flow(kDefaultFlowName, story);
             
 			OutputStreamDirty();
+            _aliveFlowNamesDirty = true;
 
             evaluationStack = new List<Runtime.Object> ();
 
@@ -409,6 +440,7 @@ namespace Ink.Runtime
             if( !_namedFlows.TryGetValue(flowName, out flow) ) {
                 flow = new Flow(flowName, story);
                 _namedFlows[flowName] = flow;
+                _aliveFlowNamesDirty = true;
             }
 
             _currentFlow = flow;
@@ -435,6 +467,7 @@ namespace Ink.Runtime
             }
 
             _namedFlows.Remove(flowName);
+            _aliveFlowNamesDirty = true;
         }
 
         // Warning: Any Runtime.Object content referenced within the StoryState will
@@ -465,6 +498,7 @@ namespace Ink.Runtime
                 foreach(var namedFlow in _namedFlows)
                     copy._namedFlows[namedFlow.Key] = namedFlow.Value;
                 copy._namedFlows[_currentFlow.name] = copy._currentFlow;
+                copy._aliveFlowNamesDirty = true;
             }
 
             if (hasError) {
@@ -649,6 +683,7 @@ namespace Ink.Runtime
             }
 
             OutputStreamDirty();
+            _aliveFlowNamesDirty = true;
 
             variablesState.SetJsonToken((Dictionary < string, object> )jObject["variablesState"]);
             variablesState.callStack = _currentFlow.callStack;
@@ -1245,6 +1280,7 @@ namespace Ink.Runtime
         Flow _currentFlow;
         Dictionary<string, Flow> _namedFlows;
         const string kDefaultFlowName = "DEFAULT_FLOW";
+        bool _aliveFlowNamesDirty = true;
     }
 }
 


### PR DESCRIPTION
Added those functions to Story:

- `story.aliveFlowNames` - the names of currently alive flows. A flow is alive if it's previously been switched to and hasn't been destroyed. Does not include default flow.
- `story.currentFlowIsDefaultFlow` - true if the default flow is currently active. By definition, will also return true if not using flow functionality.
- `story.currentFlowName` — a string containing the name of the currently active flow. May contain internal identifier for default flow, so use `currentFlowIsDefaultFlow` to check first.