### PR TITLE
Added partial support for external functions to the command line player

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -3353,7 +3353,11 @@ If a particular character range that you would like to use within identifiers is
 # Addendum: Ink + Engine Integration
 
 hey what's up sorry i'm very tired i'm not going to try to write professionally
+
 there's more documentation on how to use ink with an engine, and the code that ink provides to do that
+
 it's written for unity, but it can be sorta useful for working with inkjs?
+
 you can check it out [here](https://github.com/elliotherriman/ink/blob/master/Documentation/RunningYourInk.md)
+
 (that said, i can probably answer any questions you have so hit me up)

--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -39,7 +39,7 @@
 	 * [7) Long example: crime scene](#7-long-example-crime-scene)
 	 * [8) Summary](#8-summary)
    * [Part 6: International character support in identifiers](#part-6-international-character-support-in-identifiers)
-   * [Addendum: Ink + Engine Integration](#addendum-ink-engine-integration)
+   * [Addendum: Ink + Engine Integration](#addendum-ink--engine-integration)
 </details>
 
 ## Introduction

--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -39,6 +39,7 @@
 	 * [7) Long example: crime scene](#7-long-example-crime-scene)
 	 * [8) Summary](#8-summary)
    * [Part 6: International character support in identifiers](#part-6-international-character-support-in-identifiers)
+   * [Addendum: Ink + Engine Integration](#addendum-ink-engine-integration)
 </details>
 
 ## Introduction
@@ -3348,3 +3349,11 @@ Below is a listing of the currently supported identifier ranges.
 **NOTE!** ink files should be saved in UTF-8 format, which ensures that the above character ranges are supported.
 
 If a particular character range that you would like to use within identifiers isn't supported, feel free to open an [issue](https://github.com/inkle/ink/issues/new) or [pull request](https://github.com/inkle/ink/pulls) on the main ink repo.
+
+# Addendum: Ink + Engine Integration
+
+hey what's up sorry i'm very tired i'm not going to try to write professionally
+there's more documentation on how to use ink with an engine, and the code that ink provides to do that
+it's written for unity, but it can be sorta useful for working with inkjs?
+you can check it out [here](https://github.com/elliotherriman/ink/blob/master/Documentation/RunningYourInk.md)
+(that said, i can probably answer any questions you have so hit me up)

--- a/README.md
+++ b/README.md
@@ -162,13 +162,14 @@ To compile the ink, either export from Inky (File -> Export to JSON). Or if you'
 
 To run the binaries, you need to install [.NET Core Runtime 2.2]((https://dotnet.microsoft.com/download)) or newer (included in SDK).
 
+## Need help?
+
+* [Discord](https://discord.gg/inkle) - we have an active community of ink users who would be happy to help you out. Discord is probably the best place to find the answer to your question.
+* [GitHub Discussions](https://github.com/inkle/ink/discussions) - Or, you can ask a question here on GitHub. (Note: we used to use Issues for general Q&A, but we have now migrated.)
+
 ## How to contribute
 
-We’d of course appreciate any bug fixes you might find!
-
-We're using GitHub issues both as a discussion forum and as a bug tracker, so [create a GitHub issue](https://github.com/inkle/ink/issues/new) if you want to start a discussion or request a feature, and please label appropriately. Or if you want to get in touch with us directly, [email us](mailto:info@inklestudios.com).
-
-We also have a [Discord server](https://discord.gg/inkle), where you may find other people using ink to chat with (as well as inklers!)
+We’d of course appreciate any bug fixes you might find - feel free to submit a pull request. However, usually we're actively working on a game, so it might take a little while for us to take a look at a non-trivial pull request. Apologies in advance if it takes a while to get a response!
 
 ## Architectural overview
 

--- a/inklecate/CommandLinePlayer.cs
+++ b/inklecate/CommandLinePlayer.cs
@@ -276,6 +276,56 @@ namespace Ink
             return result;
         }
 
+        public string RequestExternalFunctionResult(string functionName, object[] args)
+        {
+            var arguments = "";
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i] is string) args[i] = "\"" + args[i] + "\"";
+                arguments += args[i];
+                if (i + 1 < args.Length) arguments += ", ";
+            }
+
+            if( !_jsonOutput ) {
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.Write("Enter result for " + functionName + "("+ arguments + ") > ");
+                Console.ResetColor();
+            }
+            else{                
+                var writer = new Runtime.SimpleJson.Writer();
+                writer.WriteObjectStart();
+                writer.WriteProperty("external-function", functionName);
+                if (arguments != "")
+                {
+                    writer.WritePropertyStart("arguments");
+                    writer.WriteArrayStart();
+                    writer.Write(arguments);
+                    writer.WriteArrayEnd();
+                    writer.WritePropertyEnd();
+                }
+                writer.WriteObjectEnd();
+                Console.WriteLine(writer.ToString());
+            }
+
+            string userInput = Console.ReadLine ();
+
+            // If we have null user input, it means that we're
+            // "at the end of the stream", or in other words, the input
+            // stream has closed, so there's nothing more we can do.
+            // We return immediately, since otherwise we get into a busy
+            // loop waiting for user input.
+            if (userInput == null) {
+                if( _jsonOutput ) {
+                    Console.WriteLine ("{\"close\": true}");
+                } else {
+                    Console.WriteLine ("<User input stream closed.>");
+                }
+            }
+
+            return userInput;
+        }
+
+
         Compiler _compiler;
         bool _jsonOutput;
         List<string> _errors = new List<string>();


### PR DESCRIPTION
Okay, I'm not sure if this is in line with your vision for Ink, so no pressure here. But I developed this for my own personal use, and it's working well, so wanted to at least share it in some sort of public fashion in case others find it useful.

These changes add partial support for external functions to Inklecate's command line player. If an external function is called during play mode, Inklecate will print its name and arguments, and wait for input via stdin. Writing a value to stdin will resume play, and Inklecate will treat that input as the return value of the external function. 

While this feature could be useful for playing games or debugging in the terminal itself, the significance here lies in JSON output. Enabling that allows another program, such as Inky, to receive and return values seamlessly. In this case, the program would also need to gracefully handle cases where a function is requested, but doesn't exist, or runs into errors.

External functions can be enabled using the argument "-e", and by default will match all external functions defined in the input ink. However, an optional whitelist can be provided via a comma separated list of function names. For example:

`./inklecate -p -e` will request values for all external functions found within the input text.
`./inklecate -p -e function1` will only request input when function1 is called.
`./inklecate -p -e function1, function2` will only request input when function1 or function2 is called.