### PR TITLE
Plugin support for the compiler!

### DIFF
--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -38,6 +38,9 @@ namespace Ink
 
         public Runtime.Story Compile ()
         {
+            if( _pluginManager != null )
+                _inputString = _pluginManager.PreParse(_inputString);
+
             Parse();
 
             if( _pluginManager != null )

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -41,7 +41,7 @@ namespace Ink
             Parse();
 
             if( _pluginManager != null )
-                _pluginManager.PostParse(_parsedStory);
+                _parsedStory = _pluginManager.PostParse(_parsedStory);
 
             if (_parsedStory != null && !_hadParseError) {
 
@@ -50,7 +50,7 @@ namespace Ink
                 _runtimeStory = _parsedStory.ExportRuntime (_options.errorHandler);
 
                 if( _pluginManager != null )
-                    _pluginManager.PostExport (_parsedStory, _runtimeStory);
+                    _runtimeStory = _pluginManager.PostExport (_parsedStory, _runtimeStory);
             } else {
                 _runtimeStory = null;
             }

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -9,7 +9,7 @@ namespace Ink
         public class Options
         {
             public string sourceFilename;
-            public List<string> pluginNames;
+            public List<string> pluginDirectories;
             public bool countAllVisits;
             public Ink.ErrorHandler errorHandler;
             public Ink.IFileHandler fileHandler;
@@ -25,8 +25,8 @@ namespace Ink
         {
             _inputString = inkSource;
             _options = options ?? new Options();
-            if( _options.pluginNames != null )
-                _pluginManager = new PluginManager (_options.pluginNames);
+            if( _options.pluginDirectories != null )
+                _pluginManager = new PluginManager (_options.pluginDirectories);
         }
 
         public Parsed.Story Parse()

--- a/compiler/Plugins/Plugin.cs
+++ b/compiler/Plugins/Plugin.cs
@@ -8,12 +8,12 @@ namespace Ink
 
         // Hook for immediately after the story has been parsed into its basic Parsed hierarchy.
         // Could be useful for modifying the story before it's exported.
-        void PostParse(Parsed.Story parsedStory);
+        void PostParse(ref Parsed.Story parsedStory);
 
         // Hook for after parsed story has been converted into its runtime equivalent. Note that
         // during this process the parsed story will have changed structure too, to take into 
         // account analysis of the structure of Weave, for example.
-        void PostExport(Parsed.Story parsedStory, Runtime.Story runtimeStory);
+        void PostExport(Parsed.Story parsedStory, ref Runtime.Story runtimeStory);
     }
 }
 

--- a/compiler/Plugins/Plugin.cs
+++ b/compiler/Plugins/Plugin.cs
@@ -6,6 +6,8 @@ namespace Ink
     {  
         // Hooks: if in doubt use PostExport, since the parsedStory is in a more finalised state.
 
+        void PreParse(ref string storyContent);
+        
         // Hook for immediately after the story has been parsed into its basic Parsed hierarchy.
         // Could be useful for modifying the story before it's exported.
         void PostParse(ref Parsed.Story parsedStory);

--- a/compiler/Plugins/PluginManager.cs
+++ b/compiler/Plugins/PluginManager.cs
@@ -1,37 +1,65 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 
 namespace Ink
 {
     public class PluginManager
     {
-        public PluginManager (List<string> pluginNames)
+        public PluginManager (List<string> pluginDirectories)
         {
             _plugins = new List<IPlugin> ();
 
-            // TODO: Make these plugin names DLL filenames, and load up their assemblies
-            foreach (string pluginName in pluginNames) {
-                //if (pluginName == "ChoiceListPlugin") {
-                //    _plugins.Add (new InkPlugin.ChoiceListPlugin ());
-                //}else  
+            foreach (string pluginName in pluginDirectories) 
+            {
+                foreach (string file in Directory.GetFiles(pluginName, "*.dll"))
                 {
-                    throw new System.Exception ("Plugin not found");
+                    foreach (Type type in Assembly.LoadFile(Path.GetFullPath(file)).GetExportedTypes())
+                    {
+                        if (typeof(IPlugin).IsAssignableFrom(type))
+                        {
+                            _plugins.Add((IPlugin)Activator.CreateInstance(type));
+                        }
+                    }
                 }
             }
         }
 
-        public void PostParse(Parsed.Story parsedStory)
+        public string PreParse(string storyContent)
         {
-            foreach (var plugin in _plugins) {
-                plugin.PostParse (parsedStory);
+            object[] args = new object[] { storyContent };
+
+            foreach (var plugin in _plugins) 
+            {
+                typeof(IPlugin).InvokeMember("PreParse", BindingFlags.InvokeMethod, null, plugin, args);
             }
+
+            return (string)args[0];
         }
 
-        public void PostExport(Parsed.Story parsedStory, Runtime.Story runtimeStory)
+        public Parsed.Story PostParse(Parsed.Story parsedStory)
         {
-            foreach (var plugin in _plugins) {
-                plugin.PostExport (parsedStory, runtimeStory);
+            object[] args = new object[] { parsedStory };
+
+            foreach (var plugin in _plugins) 
+            {
+                typeof(IPlugin).InvokeMember("PostParse", BindingFlags.InvokeMethod, null, plugin, args);
             }
+
+            return (Parsed.Story)args[0];
+        }
+
+        public Runtime.Story PostExport(Parsed.Story parsedStory, Runtime.Story runtimeStory)
+        {
+            object[] args = new object[] { parsedStory, runtimeStory };
+
+            foreach (var plugin in _plugins) 
+            {
+                typeof(IPlugin).InvokeMember("PostExport", BindingFlags.InvokeMethod, null, plugin, args);
+            }
+
+            return (Runtime.Story)args[1];
         }
 
         List<IPlugin> _plugins;

--- a/compiler/Plugins/PluginManager.cs
+++ b/compiler/Plugins/PluginManager.cs
@@ -26,17 +26,17 @@ namespace Ink
             }
         }
 
-        public string PreParse(string storyContent)
-        {
-            object[] args = new object[] { storyContent };
+		public string PreParse(string storyContent)
+		{
+			object[] args = new object[] { storyContent };
 
             foreach (var plugin in _plugins) 
             {
                 typeof(IPlugin).InvokeMember("PreParse", BindingFlags.InvokeMethod, null, plugin, args);
             }
 
-            return (string)args[0];
-        }
+			return (string)args[0];
+		}
 
         public Parsed.Story PostParse(Parsed.Story parsedStory)
         {
@@ -47,7 +47,7 @@ namespace Ink
                 typeof(IPlugin).InvokeMember("PostParse", BindingFlags.InvokeMethod, null, plugin, args);
             }
 
-            return (Parsed.Story)args[0];
+			return (Parsed.Story)args[0];
         }
 
         public Runtime.Story PostExport(Parsed.Story parsedStory, Runtime.Story runtimeStory)
@@ -59,7 +59,7 @@ namespace Ink
                 typeof(IPlugin).InvokeMember("PostExport", BindingFlags.InvokeMethod, null, plugin, args);
             }
 
-            return (Runtime.Story)args[1];
+			return (Runtime.Story)args[1];
         }
 
         List<IPlugin> _plugins;

--- a/inklecate/CommandLineTool.cs
+++ b/inklecate/CommandLineTool.cs
@@ -37,7 +37,8 @@ namespace Ink
                 "   -j:              Output in JSON format (for communication with tools like Inky)\n"+
                 "   -s:              Print stats about story including word count in JSON format\n" +
                 "   -v:              Verbose mode - print compilation timings\n"+
-                "   -k:              Keep inklecate running in play mode even after story is complete\n");
+                "   -k:              Keep inklecate running in play mode even after story is complete\n" +
+                "   -x <directory>:              Import plugins for the compiler.");
             Environment.Exit (ExitCodeError);
         }
 

--- a/inklecate/CommandLineTool.cs
+++ b/inklecate/CommandLineTool.cs
@@ -100,7 +100,7 @@ namespace Ink
 
                 compiler = new Compiler (inputString, new Compiler.Options {
                     sourceFilename = opts.inputFile,
-                    pluginNames = pluginNames,
+                    pluginDirectories = pluginDirectories,
                     countAllVisits = opts.countAllVisits,
                     errorHandler = OnError
                 });
@@ -304,10 +304,10 @@ namespace Ink
             }
 
 			opts = new Options();
-            pluginNames = new List<string> ();
+            pluginDirectories = new List<string> ();
 
             bool nextArgIsOutputFilename = false;
-            bool nextArgIsPlugin = false;
+            bool nextArgIsPluginDirectory = false;
 
 			// Process arguments
             int argIdx = 0;
@@ -316,9 +316,9 @@ namespace Ink
                 if (nextArgIsOutputFilename) {
                     opts.outputFile = arg;
                     nextArgIsOutputFilename = false;
-                } else if (nextArgIsPlugin) {
-                    pluginNames.Add (arg);
-                    nextArgIsPlugin = false;
+                } else if (nextArgIsPluginDirectory) {
+                    pluginDirectories.Add (arg);
+                    nextArgIsPluginDirectory = false;
                 }
 
 				// Options
@@ -348,7 +348,7 @@ namespace Ink
                             opts.countAllVisits = true;
                             break;
                         case 'x':
-                            nextArgIsPlugin = true;
+                            nextArgIsPluginDirectory = true;
                             break;
                         case 'k':
                             opts.keepOpenAfterStoryFinish = true;
@@ -372,7 +372,7 @@ namespace Ink
 		}
 
         Options opts;
-        List<string> pluginNames;
+        List<string> pluginDirectories;
 
         List<string> _errors = new List<string>();
         List<string> _warnings = new List<string>();


### PR DESCRIPTION
Here we go! The ink compiler has plugin support now! Pass `-x directory` on the command line, and inklecate will import all the .dlls it finds in that folder (as long as those .dlls contain classes which implement the interface `Ink.IPlugin`).

The only significant change I've made here (beyond finishing the unfinished code) was the addition of a PreParse method in the `IPlugin` interface, which accepts and returns a string. A preprocessor, if you will.