### PR TITLE
Correct spelling of "pedant"

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1349,7 +1349,7 @@ If more complex operations are required, one can write functions (using recursio
 
 #### RANDOM(min, max) 
 
-Ink can generate random integers if required using the RANDOM function. RANDOM is authored to be like a dice (yes, pendants, we said *a dice*), so the min and max values are both inclusive. 
+Ink can generate random integers if required using the RANDOM function. RANDOM is authored to be like a dice (yes, pedants, we said *a dice*), so the min and max values are both inclusive. 
 
 	~ temp dice_roll = RANDOM(1, 6) 
 	
@@ -2601,7 +2601,7 @@ It's probably also useful to have an is/are function to hand:
 		
 	My favourite dinosaurs {isAre(favouriteDinosaurs)} {listWithCommas(favouriteDinosaurs, "all extinct")}.
 
-And to be pendantic:
+And to be pedantic:
 
 	My favourite dinosaur{LIST_COUNT(favouriteDinosaurs) != 1:s} {isAre(favouriteDinosaurs)} {listWithCommas(favouriteDinosaurs, "all extinct")}.
 


### PR DESCRIPTION
The first change was ambiguous, "pendants" means something along "things that are equal to", whereas you meant "pedants", people who are very concerned about the accuracy of things (like I am). 
The second change: "pendantic" isn't a word. You meant to write "pedantic". 
I'm unsure whether this is a volitional typo or you didn't know about the correct spelling of pedant(ic), because it's kinda funny as it is.