### PR TITLE
Made links relative in documentation

### DIFF
--- a/Documentation/ArchitectureAndDevOverview.md
+++ b/Documentation/ArchitectureAndDevOverview.md
@@ -64,7 +64,7 @@ Other transformers and structuring concepts exist, but hopefully this should giv
 
 ## Runtime code generation
 
-The parsed hierarchy closely resembles the ink as it was originally written. However, the data that's loaded by the ink engine at runtime is very different. It's built out of smaller, more fundamental units, sort of like byte code, though not that low level. This content is exported to a JSON based format ready to be loaded by the runtime engine within the game. For more information on this format, [see the documentation](https://github.com/inkle/ink/blob/master/Documentation/ink_JSON_runtime_format.md).
+The parsed hierarchy closely resembles the ink as it was originally written. However, the data that's loaded by the ink engine at runtime is very different. It's built out of smaller, more fundamental units, sort of like byte code, though not that low level. This content is exported to a JSON based format ready to be loaded by the runtime engine within the game. For more information on this format, [see the documentation](ink_JSON_runtime_format.md).
 
 In the runtime, there's no concept of Knots, Stitches, Weave, or other high level ink structures. Instead, the runtime consists mainly of general purpose `Runtime.Container` objects and content, inheriting from `Runtime.Object`.
 
@@ -101,7 +101,7 @@ As mentioned above, the runtime code is built out of smaller, simpler, objects c
 
 All the higher level structures, including the story itself, any knots and stitches, and even choices, are built out of containers. Within the containers, content is iterated through sequentially, and appended to the output.
 
-This structure is loaded by the ink engine in a [JSON based format](https://github.com/inkle/ink/blob/master/Documentation/ink_JSON_runtime_format.md).
+This structure is loaded by the ink engine in a [JSON based format](ink_JSON_runtime_format.md).
 
 ### Containers
 

--- a/Documentation/RunningYourInk.md
+++ b/Documentation/RunningYourInk.md
@@ -4,7 +4,7 @@
 
 *Note that although these instructions are written with Unity in mind, it's possible (and straightforward) to run your ink in a non-Unity C# environment.*
 
-* Download the [latest version of the ink-unity-integration Unity package](https://github.com/inkle/ink-unity-integration/releases), and add to your project.
+* Download the [latest version of the ink-unity-integration Unity package](/inkle/ink-unity-integration/releases), and add to your project.
 * Select your `.ink` file in Unity, and you should see a *Play* button in the file's inspector.
 * Click it, and you should get an Editor window that lets you play (preview) your story.
 * To integrate into your game, see **Getting started with the runtime API**, below.
@@ -174,7 +174,7 @@ Note that [Inky](https://github.com/inkle/inky) will use the title tag in this f
 
 ## Jumping to a particular "scene"
 
-Top level named sections in **ink** are called knots (see [the writing tutorial](https://github.com/inkle/ink/blob/master/Documentation/WritingWithInk.md)). You can tell the runtime engine to jump to a particular named knot:
+Top level named sections in **ink** are called knots (see [the writing tutorial](WritingWithInk.md)). You can tell the runtime engine to jump to a particular named knot:
 
     _inkStory.ChoosePathString("myKnotName");
 
@@ -241,7 +241,7 @@ Remember that in addition to external functions, there are other good ways to co
 
 * You can set up a variable observer if you just want the game to know when some state has changed. This is perfect for say, changing the score in the UI.
 
-* You can use [tags](https://github.com/inkle/ink/blob/master/Documentation/RunningYourInk.md#marking-up-your-ink-content-with-tags) to add invisible metadata to a line in ink.
+* You can use [tags](RunningYourInk.md#marking-up-your-ink-content-with-tags) to add invisible metadata to a line in ink.
 
 * In inkle's games such as [Heaven's Vault](https://www.inklestudios.com/heavensvault), we use the text itself to write instructions to the game, and then have a game-specific text parser decide what to do with it. This is a very flexible approach, and allows us to have a different style of writing on each project. For example, we use the following syntax to ask the game to set up a particular camera shot:
 
@@ -281,7 +281,7 @@ public void BindExternalFunction(string funcName, Func<object> func, bool lookah
 
 ### Fallbacks for external functions
 
-When testing your story, either in [Inky](https://github.com/inkle/inky) or in the [ink-unity integration](https://github.com/inkle/ink-unity-integration/) player window, you don't get an opportunity to bind a game function before running the story. To get around this, you can define a *fallback function* within ink, which is run if the `EXTERNAL` function can't be found. To do so, simply create an ink function with the same name and parameters. For example, for the above `multiply` example, create the ink function:
+When testing your story, either in [Inky](/inkle/inky) or in the [ink-unity integration](/inkle/ink-unity-integration/) player window, you don't get an opportunity to bind a game function before running the story. To get around this, you can define a *fallback function* within ink, which is run if the `EXTERNAL` function can't be found. To do so, simply create an ink function with the same name and parameters. For example, for the above `multiply` example, create the ink function:
 
 ```
 === function multiply(x,y) ===

--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -103,7 +103,7 @@ Text content from the game will appear 'as is' when the engine runs. However, it
 
 	A line of normal game-text. # colour it blue
 
-These don't show up in the main text flow, but can be read off by the game and used as you see fit. See [RunningYourInk](https://github.com/inkle/ink/blob/master/Documentation/RunningYourInk.md#marking-up-your-ink-content-with-tags) for more information.
+These don't show up in the main text flow, but can be read off by the game and used as you see fit. See [Running Your Ink](RunningYourInk.md#marking-up-your-ink-content-with-tags) for more information.
 
  
 ## 2) Choices 
@@ -1891,7 +1891,7 @@ Constants are simply a way to allow you to give story states easy-to-understand 
 
 ## 7) Advanced: Game-side logic 
 
-There are two core ways to provide game hooks in the **ink** engine. External function declarations in ink allow you to directly call C# functions in the game, and variable observers are callbacks that are fired in the game when ink variables are modified. Both of these are described in [Running your ink](https://github.com/inkle/ink/blob/master/Documentation/RunningYourInk.md).
+There are two core ways to provide game hooks in the **ink** engine. External function declarations in ink allow you to directly call C# functions in the game, and variable observers are callbacks that are fired in the game when ink variables are modified. Both of these are described in [Running your ink](RunningYourInk.md).
 
 # Part 4: Advanced Flow Control
 
@@ -3350,4 +3350,4 @@ Below is a listing of the currently supported identifier ranges.
 
 **NOTE!** ink files should be saved in UTF-8 format, which ensures that the above character ranges are supported.
 
-If a particular character range that you would like to use within identifiers isn't supported, feel free to open an [issue](https://github.com/inkle/ink/issues/new) or [pull request](https://github.com/inkle/ink/pulls) on the main ink repo.
+If a particular character range that you would like to use within identifiers isn't supported, feel free to open an [issue](/inkle/ink/issues/new) or [pull request](/inkle/ink/pulls) on the main ink repo.

--- a/Documentation/ink_JSON_runtime_format.md
+++ b/Documentation/ink_JSON_runtime_format.md
@@ -1,6 +1,6 @@
 # ink's JSON runtime format
 
-When ink is compiled to JSON, it is converted to a low level format for use by the runtime, and is made up of smaller, simpler building blocks. For an overview of the full pipeline, including a description of the runtime itself see the [Architecture and Development documentation](https://github.com/inkle/ink/blob/master/Documentation/ArchitectureAndDevOverview.md).
+When ink is compiled to JSON, it is converted to a low level format for use by the runtime, and is made up of smaller, simpler building blocks. For an overview of the full pipeline, including a description of the runtime itself see the [Architecture and Development documentation](ArchitectureAndDevOverview.md).
 
 ## Top level
 


### PR DESCRIPTION
GitHub links, if they are also pointing to GitHub, don't need to be prefixed with `https://github.com/`, I've decided to truncate some of the links.