### PR TITLE
Flush the writer when a full object is written

### DIFF
--- a/ink-engine-runtime/SimpleJson.cs
+++ b/ink-engine-runtime/SimpleJson.cs
@@ -333,6 +333,8 @@ namespace Ink.Runtime
                 Assert(state == State.Object);
                 _writer.Write("}");
                 _stateStack.Pop();
+                if (state == State.None)
+                    _writer.Flush();
             }
 
             public void WriteProperty(string name, Action<Writer> inner)


### PR DESCRIPTION
When writing a large amount of JSON to a StreamWriter it's possible for the JSON to get truncated because the writer is never flushed before it's closed. This PR changes SimpleJson to flush whenever the end of an object is written and the state stack becomes empty.

To reproduce the truncation (before this change) you can do:

```c#
using (var stream = File.Open(jsonFilePath), FileMode.Create))
{
    story.ToJson(stream);
}
```

On my box my particular ink script results in a truncated JSON file a bit longer than 5,000 chars. After the fix it results in a complete JSON file over 6,000 chars.