### PR TITLE
A few misc changes!

### DIFF
--- a/ink-engine-runtime/InkList.cs
+++ b/ink-engine-runtime/InkList.cs
@@ -75,13 +75,22 @@ namespace Ink.Runtime
         /// </summary>
         public override bool Equals (object obj)
         {
-            if (obj is InkListItem) {
-                var otherItem = (InkListItem)obj;
-                return otherItem.itemName   == itemName 
-                    && otherItem.originName == originName;
-            }
-
+            if (obj is InkListItem) 
+                return Equals((InkListItem)obj);
             return false;
+        }
+
+        public bool Equals (InkListItem otherItem)
+        {
+            return otherItem.itemName == itemName && otherItem.originName == originName;
+        }
+
+        public static bool operator == (InkListItem left, InkListItem right) {
+            return left.Equals(right);
+        }
+    
+        public static bool operator != (InkListItem left, InkListItem right) {
+            return !(left == right);
         }
 
         /// <summary>
@@ -138,6 +147,16 @@ namespace Ink.Runtime
             else
                 throw new System.Exception ("InkList origin could not be found in story when constructing new list: " + singleOriginListName);
         }
+        
+        /// <summary>
+        /// Creates a new list with this item as the only member.
+        /// The origin Story is needed in order to be able to look up that definition.
+        /// </summary>
+		/// <returns>InkList created from this list item</returns>
+		/// <param name="originStory">Origin story.</param>
+        public InkList (InkListItem inkListItem, Story originStory) : this (inkListItem.originName, originStory) {
+            AddItem(inkListItem);
+        }
 
         public InkList (KeyValuePair<InkListItem, int> singleElement)
         {
@@ -157,7 +176,6 @@ namespace Ink.Runtime
 			else 
                 throw new System.Exception ("Could not find the InkListItem from the string '" + myListItem + "' to create an InkList because it doesn't exist in the original list definition in ink.");
 		}
-
 
         /// <summary>
         /// Adds the given item to the ink list. Note that the item must come from a list definition that
@@ -190,30 +208,44 @@ namespace Ink.Runtime
         /// <summary>
         /// Adds the given item to the ink list, attempting to find the origin list definition that it belongs to.
         /// The item must therefore come from a list definition that is already "known" to this list, so that the
-        /// item's value can be looked up. By "known", we mean that it already has items in it from that source, or
+        /// item's value can be looked up.
+        /// By "known", we mean that it already has items in it from that source, or
         /// it did at one point - it can't be a completely fresh empty list, or a list that only contains items from
         /// a different list definition.
+        /// You can also provide the Story object, so in the case of an unknown element, it can be created fresh
         /// </summary>
-        public void AddItem (string itemName)
+        public void AddItem(string itemName, Story storyObject = null)
         {
             ListDefinition foundListDef = null;
 
-            foreach (var origin in origins) {
-                if (origin.ContainsItemWithName (itemName)) {
-                    if (foundListDef != null) {
-                        throw new System.Exception ("Could not add the item " + itemName + " to this list because it could come from either " + origin.name + " or " + foundListDef.name);
-                    } else {
-                        foundListDef = origin;
+            if (origins != null) { 
+                foreach (var origin in origins) {
+                    if (origin.ContainsItemWithName(itemName)) {
+                        if (foundListDef != null) {
+                            throw new System.Exception("Could not add the item " + itemName + " to this list because it could come from either " + origin.name + " or " + foundListDef.name);
+                        } else {
+                            foundListDef = origin;
+                        }
                     }
                 }
             }
 
             if (foundListDef == null)
-                throw new System.Exception ("Could not add the item " + itemName + " to this list because it isn't known to any list definitions previously associated with this list.");
-
-            var item = new InkListItem (foundListDef.name, itemName);
-            var itemVal = foundListDef.ValueForItem(item);
-            this [item] = itemVal;
+            {
+                if (storyObject == null)
+                    throw new System.Exception("Could not add the item " + itemName + " to this list because it isn't known to any list definitions previously associated with this list, and no ink Story object was provided to create it from.");
+                else
+                {
+                    var newItem = FromString(itemName, storyObject).orderedItems[0];
+                    this[newItem.Key] = newItem.Value;
+                }
+            }
+            else
+            {
+                var item = new InkListItem(foundListDef.name, itemName);
+                var itemVal = foundListDef.ValueForItem(item);
+                this[item] = itemVal;
+            }
         }
 
         /// <summary>
@@ -373,7 +405,8 @@ namespace Ink.Runtime
         }
 
         /// <summary>
-        /// Fast test for the existence of any intersection between the current list and another
+        /// Returns a boolean declaring if two lists have an intersection
+        /// Loops through the FIRST list, so for speed, test small.HasIntersection(larger)
         /// </summary>
         public bool HasIntersection(InkList otherList)
         {

--- a/ink-engine-runtime/ListDefinitionsOrigin.cs
+++ b/ink-engine-runtime/ListDefinitionsOrigin.cs
@@ -43,7 +43,8 @@ namespace Ink.Runtime
         public ListValue FindSingleItemListWithName (string name)
         {
 			ListValue val = null;
-			_allUnambiguousListValueCache.TryGetValue(name, out val);
+            if (!string.IsNullOrWhiteSpace(name))
+			    _allUnambiguousListValueCache.TryGetValue(name, out val);
 			return val;
         }
 

--- a/ink-engine-runtime/Path.cs
+++ b/ink-engine-runtime/Path.cs
@@ -240,6 +240,28 @@ namespace Ink.Runtime
             }
         }
 		string _componentsString;
+        
+        // Path to the container that includes this path
+        public string containerString {
+            get {
+				if( _containerString == null ) {
+                    var sb = new System.Text.StringBuilder ();
+                    for (int i = 0; i < _components.Count; i++) {
+                        Component component = _components[i];
+                        if ( !component.isIndex ) {
+                            if (i > 0) sb.Append ('.');
+                            sb.Append(component.name);
+                        } else {
+                            break;
+                        }
+                    }
+					if (isRelative) sb.Insert(0, ".");
+                    _containerString = sb.ToString();
+				}
+				return _containerString;
+            }
+        }
+		string _containerString;
 
 		public override string ToString()
 		{

--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -311,7 +311,10 @@ namespace Ink.Runtime
             ResetGlobals ();
         }
 
-        void ResetErrors()
+        /// <summary>
+        /// Reset the runtime error and warning list within the state.
+        /// </summary>
+        public void ResetErrors()
         {
             _state.ResetErrors ();
         }
@@ -1801,7 +1804,18 @@ namespace Ink.Runtime
         /// </summary>
         public bool allowExternalFunctionFallbacks { get; set; }
 
-        public void CallExternalFunction(string funcName, int numberOfArguments)
+        public bool TryGetExternalFunction(string functionName, out ExternalFunction externalFunction) {
+            ExternalFunctionDef externalFunctionDef;
+            if(_externals.TryGetValue (functionName, out externalFunctionDef)) {
+                externalFunction = externalFunctionDef.function;
+                return true;
+            } else {
+                externalFunction = null;
+                return false;
+            }
+        }
+
+        private void CallExternalFunction(string funcName, int numberOfArguments)
         {
             ExternalFunctionDef funcDef;
             Container fallbackFunctionContainer = null;

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -227,12 +227,22 @@ namespace Ink.Runtime
             }
         }
 
+        /// <summary>
+        // String representation of the container (knot/stitch/function etc) location where the story currently is. 
+        // This resolves some practical use issues with currentPathString. Key differences are:
+        // This doesn't contain the line index/choice index of the path, and only returns the container, ie: "knot.stitch"
+        // This returns a valid path when the story cannot continue, ie: at a choice point/story end.
+        /// </summary>
+        public string currentContainerPathString { get; set; }
+
         public Runtime.Pointer currentPointer {
             get {
                 return callStack.currentElement.currentPointer;
             }
             set {
                 callStack.currentElement.currentPointer = value;
+                if(!value.isNull)
+                    currentContainerPathString = value.path.containerString;
             }
         }
 
@@ -603,6 +613,9 @@ namespace Ink.Runtime
             if (!divertedPointer.isNull)
                 writer.WriteProperty("currentDivertTarget", divertedPointer.path.componentsString);
                 
+            if(currentContainerPathString != null)
+                writer.WriteProperty("currentContainerPathString", currentContainerPathString);
+            
             writer.WriteProperty("visitCounts", w => Json.WriteIntDictionary(w, _visitCounts));
             writer.WriteProperty("turnIndices", w => Json.WriteIntDictionary(w, _turnIndices));
 
@@ -697,6 +710,14 @@ namespace Ink.Runtime
                 divertedPointer = story.PointerAtPath (divertPath);
             }
                 
+            object _currentContainerPathString;
+            if(jObject.TryGetValue("currentContainerPathString", out _currentContainerPathString)) {
+                currentContainerPathString = _currentContainerPathString.ToString();
+            } else {
+                currentContainerPathString = null;
+            }
+            
+
             _visitCounts = Json.JObjectToIntDictionary((Dictionary<string, object>)jObject["visitCounts"]);
             _turnIndices = Json.JObjectToIntDictionary((Dictionary<string, object>)jObject["turnIndices"]);
 


### PR DESCRIPTION
I've got a few changes to the version of ink I'm using that I'd love to get into the main branch! Apologies they're all in a single request.

InkList: Adds == operator for InkLists, and some other changes Jon(?) wrote for Overboard but never merged in
ListDefinitionsOrigin: Null input check. _allUnambiguousListValueCache items should never be null, so we don't even want to check.
Story: These were changes used in the InkPlayerEditorWindow
Path+StoryState: This is a new feature! It enables you to get a more practical path string for the story state, which I've found super helpful as a way of checking where the player REALLY is in the story (which can then be used to rewind them, track state, find bugs, etc)