### PR TITLE
Package inklecate as a dotnet tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,6 @@ paket-files/
 .idea/
 *.sln.iml
 .ionide/
+
+# Ignore nuget packages
+*.nupkg

--- a/inklecate/inklecate.csproj
+++ b/inklecate/inklecate.csproj
@@ -5,6 +5,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Ink</RootNamespace>
     <AssemblyName>inklecate</AssemblyName>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>inklecate</ToolCommandName>
+    <Version>1.0.1</Version>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Publishing inklecate as a [dotnet tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) would have a lot of benefits:

- It is easier to publish than uploading a Github release with `dotnet pack` and `dotnet nuget push`
    - Incrementing the version number can be annoying to remember. But the repo already uses tags, so a tool linke [MinVer](https://github.com/adamralph/minver) would version the package automatically based on the closest tag
- It is easier to install for cli users with `dotnet tool install`
- It is easier for update for cli users with `dotnet tool update`

# Testing

Here is how I tested this change:
```
dotnet pack
dotnet tool install -g inklecate --add-source inklecate/nupkg/
cd {ink script folder}
inklecate {my-script}.ink
```
This worked great on my machine (Win10). I didn't publish the package to a nuget feed so I couldn't test it on other OSes. I'm hoping since the csproj is .Net Core, it will work in a Linux container.

# Use Case

In my particular use case, I wanted to setup a pipeline to compile my inks into json whenever I push. The problem is installing inklecate in linux is kinda a pain. I noticed that we were using .Net Core 3 so I wondered how hard it would be to convert this to a dotnet tool. Then I could use a dotnet linux container ([`mcr.microsoft.com/dotnet/sdk`](https://hub.docker.com/_/microsoft-dotnet-sdk)) and:
```
dotnet tool install -g inklecate --add-source https://nuget.pkg.github.com/inkle/index.json
inklecate *.ink
{process the .ink.jsons}
```

# Next Steps

This is just how I would go about fleshing out the pipeline:

1.  [Optional] Use [MinVer](https://github.com/adamralph/minver) to autoversion off tags
    - You can manually version via a csproj 'Version' property like I did here
2. Update travis to pack and push a nuget on certain events (eg: branch == master, tag events)
    - It would look something like this (I do this in GitLab and Github should be similar):
    ```
    dotnet nuget add source https://nuget.pkg.github.com/inkle/index.json  --name github --username inkle --password {github read/write token} --store-password-in-clear-text
    git fetch --tags # if using MinVer
    dotnet pack --configuration Release --output .
    dotnet nuget push *.nupkg --source github
    ```

# Further reading
- [Tutorial for creating a dotnet tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create)
- [Hosting nuget feed on Github](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/hosting-packages/Overview.md)
- [SO on Publishing/Consuming nugets](https://stackoverflow.com/a/62809861/4769802)
- [Publishing Nuget Package on Github](https://www.wearecogworks.com/blog/nuget-with-github-packages-tutorial/)