### PR TITLE
Force refresh of List origins when accessed via VariablesState to fix  bug where some Lists loaded from file don't get initialized.

### DIFF
--- a/ink-engine-runtime/CallStack.cs
+++ b/ink-engine-runtime/CallStack.cs
@@ -71,10 +71,15 @@ namespace Ink.Runtime
                         pointer.container = threadPointerResult.container;
                         pointer.index = (int)jElementObj ["idx"];
 
-                        if (threadPointerResult.obj == null)
+                        if (threadPointerResult.obj == null) {
                             throw new System.Exception ("When loading state, internal story location couldn't be found: " + currentContainerPathStr + ". Has the story changed since this save data was created?");
-                        else if (threadPointerResult.approximate)
-                            storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "', so it was approximated to '"+pointer.container.path.ToString()+"' to recover. Has the story changed since this save data was created?");
+                        } else if (threadPointerResult.approximate) {
+                            if (pointer.container != null) {
+                                storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "', so it was approximated to '" + pointer.container.path.ToString() + "' to recover. Has the story changed since this save data was created?");
+                            } else {
+                                storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "' and it may not be recoverable. Has the story changed since this save data was created?");
+                            }
+                        }
 					}
 
                     bool inExpressionEvaluation = (bool)jElementObj ["exp"];

--- a/ink-engine-runtime/InkList.cs
+++ b/ink-engine-runtime/InkList.cs
@@ -233,6 +233,26 @@ namespace Ink.Runtime
         // Only the story has access to the full set of lists, so that
         // the origin can be resolved from the originListName.
         public List<ListDefinition> origins;
+
+        public void RefreshOrigins(ListDefinitionsOrigin listDefsOrigin)
+        {
+            if (listDefsOrigin == null) return;
+
+            if (originNames != null)
+            {
+                if (origins == null) origins = new List<ListDefinition>();
+                origins.Clear();
+
+                foreach (var n in originNames)
+                {
+                    ListDefinition def = null;
+                    listDefsOrigin.TryListGetDefinition(n, out def);
+                    if (!origins.Contains(def))
+                        origins.Add(def);
+                }
+            }
+        }
+
         public ListDefinition originOfMaxItem {
             get {
                 if (origins == null) return null;

--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -1053,18 +1053,7 @@ namespace Ink.Runtime
             if (listValue) {
                 
                 // Update origin when list is has something to indicate the list origin
-                var rawList = listValue.value;
-				if (rawList.originNames != null) {
-					if( rawList.origins == null ) rawList.origins = new List<ListDefinition>();
-					rawList.origins.Clear();
-
-					foreach (var n in rawList.originNames) {
-                        ListDefinition def = null;
-                        story.listDefinitions.TryListGetDefinition (n, out def);
-						if( !rawList.origins.Contains(def) )
-							rawList.origins.Add (def);
-                    }
-                }
+                listValue.value.RefreshOrigins(story.listDefinitions);
             }
 
             evaluationStack.Add(obj);

--- a/ink-engine-runtime/VariablesState.cs
+++ b/ink-engine-runtime/VariablesState.cs
@@ -66,7 +66,7 @@ namespace Ink.Runtime
                 Runtime.Object varContents;
 
                 if (patch != null && patch.TryGetGlobal(variableName, out varContents))
-                    return (varContents as Runtime.Value).valueObject;
+                    return RefreshListOrigins((varContents as Runtime.Value).valueObject);
 
                 // Search main dictionary first.
                 // If it's not found, it might be because the story content has changed,
@@ -74,7 +74,7 @@ namespace Ink.Runtime
                 // Should really warn somehow, but it's difficult to see how...!
                 if ( _globalVariables.TryGetValue (variableName, out varContents) || 
                      _defaultGlobalVariables.TryGetValue(variableName, out varContents) )
-                    return (varContents as Runtime.Value).valueObject;
+                    return RefreshListOrigins((varContents as Runtime.Value).valueObject);
                 else {
                     return null;
                 }
@@ -95,6 +95,23 @@ namespace Ink.Runtime
                 SetGlobal (variableName, val);
             }
         }
+
+        private object RefreshListOrigins(object obj)
+         {
+             if (obj != null) 
+             {
+                 var inkList = obj as InkList;
+                 if (inkList != null) 
+                 {
+                     if (inkList.origins == null)
+                     {
+                         inkList.RefreshOrigins(_listDefsOrigin);
+                     }
+                 }
+             }
+
+             return obj;
+         }
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{


### PR DESCRIPTION
This is my (hacky?) fix for the bug I describe here: https://github.com/inkle/ink/issues/763

This PR adds a check when an `InkList` is accessed via `VariablesState` to see if its `origins` is null. If it is, then it tries to populate them at that point. The rest of the changes are some code refactoring to keep the origin-setting code in one place.

This has fixed my specific problem, but it's almost certainly not a comprehensive fix. Hopefully it's a useful start though.

The real fix should probably make sure all `InkList` `origins` are populated after a `LoadJson()`. I don't understand the entire runtime enough to do that.