### PR TITLE
support for Chinese identifier

### DIFF
--- a/compiler/InkParser/InkParser_CharacterRanges.cs
+++ b/compiler/InkParser/InkParser_CharacterRanges.cs
@@ -26,6 +26,8 @@ namespace Ink
 			CharacterRange.Define('\uAC00', '\uD7AF', excludes: new CharacterSet());
 	    	public static readonly CharacterRange Latin1Supplement =
 			CharacterRange.Define('\u0080', '\u00FF', excludes: new CharacterSet());
+	    	public static readonly CharacterRange Chinese =
+			CharacterRange.Define('\u4E00', '\u9FFF', excludes: new CharacterSet());
 
         private void ExtendIdentifierCharacterRanges(CharacterSet identifierCharSet)
         {
@@ -57,6 +59,7 @@ namespace Ink
                 Hebrew,
                 Korean,
 		Latin1Supplement,
+		Chinese,
             };
         }
 	}


### PR DESCRIPTION
Enables characters for languages of the Chinese and is a subset of the official * Chinese* unicode range `\u4E00`-`\u9FFF`.