### PR TITLE
Upgrade target framework and scripts from .net core 3.1 to .net 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 language: csharp
 solution: ink.sln
 mono: none
-dotnet: 3.1
+dotnet: 6.0
 cache:
   directories:
     - /home/travis/.nuget/packages/

--- a/InkTestBed/InkTestBed.csproj
+++ b/InkTestBed/InkTestBed.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <RootNamespace>InkTestBed</RootNamespace>
     <AssemblyName>InkTestBed</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To compile the ink, either export from Inky (File -> Export to JSON). Or if you'
 ## Build Requirements
 
 **All Environments:**
- * [.NET Core SDK 3.1](https://dotnet.microsoft.com/download) or newer
+ * [.NET SDK 6.0](https://dotnet.microsoft.com/download) or newer
  * Optionally [Visual Studio Code](https://code.visualstudio.com/)
 
 
@@ -156,11 +156,11 @@ To compile the ink, either export from Inky (File -> Export to JSON). Or if you'
 1. `cd` to the project you want to build (e.g., `cd inklecate`)
 2. Build using dotnet: `dotnet build -c Release`
 3. To run console apps: `dotnet run -c Release`
-    * To produce self-contained executable: `dotnet publish -r win-x64 -c Release --self-contained false`
+    * To produce self-contained executable: `dotnet publish -r win-x64 -c Release --self-contained`
     * [Recommended RIDs](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) for the platform (`-r`) are: `win-x64`, `linux-x64`, and `osx-x64`
 
 
-To run the binaries, you need to install [.NET Core Runtime 2.2]((https://dotnet.microsoft.com/download)) or newer (included in SDK).
+To run the binaries, you need to install [.NET Runtime 6.0]((https://dotnet.microsoft.com/download)) or newer (included in SDK).
 
 ## Need help?
 

--- a/build_for_inky.command
+++ b/build_for_inky.command
@@ -1,16 +1,16 @@
 cd "`dirname "$0"`"
 
 # Build for each platform
-dotnet publish -c Release -r win-x86 /p:PublishTrimmed=true /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
+dotnet publish -c Release -r win-x86 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
 mv BuildForInky/inklecate.exe BuildForInky/inklecate_win.exe
 
-dotnet publish -c Release -r osx-x64 /p:PublishTrimmed=true /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
+dotnet publish -c Release -r osx-x64 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
 mv BuildForInky/inklecate BuildForInky/inklecate_mac
 
-dotnet publish -c Release -r linux-x64 /p:PublishTrimmed=true /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
+dotnet publish -c Release -r linux-x64 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o BuildForInky inklecate/inklecate.csproj
 mv BuildForInky/inklecate BuildForInky/inklecate_linux
 
 
 # Copy the runtime and compiler debug symbols in
-cp ink-engine-runtime/bin/Release/netstandard2.0/ink-engine-runtime.pdb BuildForInky/
-cp compiler/bin/Release/netstandard2.0/ink_compiler.pdb BuildForInky/
+cp ink-engine-runtime/bin/Release/net6.0/ink-engine-runtime.pdb BuildForInky/
+cp compiler/bin/Release/net6.0/ink_compiler.pdb BuildForInky/

--- a/build_release.command
+++ b/build_release.command
@@ -2,12 +2,12 @@ cd "`dirname "$0"`"
 
 # Build the release code; this will create self-sufficient single binary
 #dotnet build -c Release inklecate/inklecate.csproj
-dotnet publish -c Release -r win-x86 /p:PublishTrimmed=true /p:PublishSingleFile=true -o ReleaseBinary/inklecate/win32 inklecate/inklecate.csproj
-dotnet publish -c Release -r linux-x64 /p:PublishTrimmed=true /p:PublishSingleFile=true -o ReleaseBinary/inklecate/lin64 inklecate/inklecate.csproj
-dotnet publish -c Release -r osx-x64 /p:PublishTrimmed=true /p:PublishSingleFile=true -o ReleaseBinary/inklecate/osx64 inklecate/inklecate.csproj
+dotnet publish -c Release -r win-x86 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o ReleaseBinary/inklecate/win32 inklecate/inklecate.csproj
+dotnet publish -c Release -r linux-x64 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o ReleaseBinary/inklecate/lin64 inklecate/inklecate.csproj
+dotnet publish -c Release -r osx-x64 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o ReleaseBinary/inklecate/osx64 inklecate/inklecate.csproj
 
 # Simply zip up inklecate executable and the DLLs together for each platform
-runtimeAndCompilerDLLs="ink-engine-runtime/bin/Release/netstandard2.0/ink-engine-runtime.dll compiler/bin/Release/netstandard2.0/ink_compiler.dll"
+runtimeAndCompilerDLLs="ink-engine-runtime/bin/Release/net6.0/ink-engine-runtime.dll compiler/bin/Release/net6.0/ink_compiler.dll"
 zip --junk-paths ReleaseBinary/inklecate_windows.zip ReleaseBinary/inklecate/win32/inklecate.exe $runtimeAndCompilerDLLs
 zip --junk-paths ReleaseBinary/inklecate_linux.zip  ReleaseBinary/inklecate/lin64/inklecate $runtimeAndCompilerDLLs
 zip --junk-paths ReleaseBinary/inklecate_mac.zip  ReleaseBinary/inklecate/osx64/inklecate $runtimeAndCompilerDLLs

--- a/ink-engine-runtime/ink-engine-runtime.csproj
+++ b/ink-engine-runtime/ink-engine-runtime.csproj
@@ -13,7 +13,7 @@
     <Copyright>inkle Ltd</Copyright>
     <RepositoryUrl>https://github.com/inkle/ink</RepositoryUrl>
     <PackageProjectUrl>https://www.inklestudios.com/ink/</PackageProjectUrl>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/1987090</PackageIconUrl>
     <Description>Runtime engine for the ink scripting language</Description>
     <RepositoryType>git</RepositoryType>

--- a/ink.sln
+++ b/ink.sln
@@ -19,6 +19,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ink_compiler", "compiler\in
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InkTestBed", "InkTestBed\InkTestBed.csproj", "{714B52DE-576A-4760-BA2E-F8483DD2CAAA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C5E94A09-51F0-4936-896B-571A1BECDC2C}"
+	ProjectSection(SolutionItems) = preProject
+		.travis.yml = .travis.yml
+		build_for_inky.command = build_for_inky.command
+		build_release.command = build_release.command
+		cleanup-binobj.ps1 = cleanup-binobj.ps1
+		profiler.command = profiler.command
+		publish-nuget.ps1 = publish-nuget.ps1
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/inklecate/inklecate.csproj
+++ b/inklecate/inklecate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Ink</RootNamespace>
     <AssemblyName>inklecate</AssemblyName>
   </PropertyGroup>

--- a/profiler.command
+++ b/profiler.command
@@ -1,5 +1,5 @@
 cd "`dirname "$0"`"
-mono --profile=log:output=output.mlpd inklecate/bin/Release/netcoreapp5.0/inklecate.dll -s > report-in-progress.txt
+mono --profile=log:output=output.mlpd inklecate/bin/Release/net6.0/inklecate.dll -s > report-in-progress.txt
 echo "----------------------------" >> report-in-progress.txt
 mprof-report --verbose output.mlpd >> report-in-progress.txt  # use --time=10.0-20.0 to select a particular time period
 rm output.mlpd

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>tests</RootNamespace>
     <AssemblyName>ink-tests</AssemblyName>
 
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
.NET 6.0 is the latest LTS release of .NET, and .NET Core 3.1 will reach [the end of support](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/) this October.

* The method of bundling everything in a single-file executable has changed between 3.1 and 6.0, in particular Windows executable is not a single file anymore
* Trimming of assemblies during single-file bundling is much more complicated and not recommended anymore, so I have disabled this feature (this means slightly increased file size of releases)
* Inclecate usage instructions in README.md should probably be changed, as it was using native Linux binary since migration to .net core 3.1