### PR TITLE
Adding null check to value pop

### DIFF
--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -1838,7 +1838,7 @@ namespace Ink.Runtime
             var arguments = new List<object>();
             for (int i = 0; i < numberOfArguments; ++i) {
                 var poppedObj = state.PopEvaluationStack () as Value;
-                var valueObj = poppedObj.valueObject;
+                var valueObj = poppedObj?.valueObject;
                 arguments.Add (valueObj);
             }
 


### PR DESCRIPTION
When an external function opens a flow, the return from that function is never acknowledged and the function is called a second time when returning to the original flow, however the arguments are all NullValues which causes a nullref. This fixes the nullref, albeit more work will be needed to address the double call of a function that opens a flow.

Noting that the alternative of creating a call stack to call after the function block is done also doesn't work, since the story will continue with the next paragraph, resulting in a rather weird requirement of calling a function just _before_ the last block to be shown.