### PR TITLE
Fix for approximate-location warning when loading a saved state, which could crash with a null pointer.

### DIFF
--- a/ink-engine-runtime/CallStack.cs
+++ b/ink-engine-runtime/CallStack.cs
@@ -71,10 +71,15 @@ namespace Ink.Runtime
                         pointer.container = threadPointerResult.container;
                         pointer.index = (int)jElementObj ["idx"];
 
-                        if (threadPointerResult.obj == null)
+                        if (threadPointerResult.obj == null) {
                             throw new System.Exception ("When loading state, internal story location couldn't be found: " + currentContainerPathStr + ". Has the story changed since this save data was created?");
-                        else if (threadPointerResult.approximate)
-                            storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "', so it was approximated to '"+pointer.container.path.ToString()+"' to recover. Has the story changed since this save data was created?");
+                        } else if (threadPointerResult.approximate) {
+                            if (pointer.container != null) {
+                                storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "', so it was approximated to '" + pointer.container.path.ToString() + "' to recover. Has the story changed since this save data was created?");
+                            } else {
+                                storyContext.Warning ("When loading state, exact internal story location couldn't be found: '" + currentContainerPathStr + "' and it may not be recoverable. Has the story changed since this save data was created?");
+                            }
+                        }
 					}
 
                     bool inExpressionEvaluation = (bool)jElementObj ["exp"];


### PR DESCRIPTION
Fix for: https://github.com/inkle/ink/issues/787