### PR TITLE
Retarget the runtime to netstandard

### DIFF
--- a/build_for_inky.command
+++ b/build_for_inky.command
@@ -12,5 +12,5 @@ mv BuildForInky/inklecate BuildForInky/inklecate_linux
 
 
 # Copy the runtime and compiler debug symbols in
-cp ink-engine-runtime/bin/Release/net6.0/ink-engine-runtime.pdb BuildForInky/
-cp compiler/bin/Release/net6.0/ink_compiler.pdb BuildForInky/
+cp ink-engine-runtime/bin/Release/netstandard2.0/ink-engine-runtime.pdb BuildForInky/
+cp compiler/bin/Release/netstandard2.0/ink_compiler.pdb BuildForInky/

--- a/build_release.command
+++ b/build_release.command
@@ -7,7 +7,7 @@ dotnet publish -c Release -r linux-x64 --self-contained /p:PublishTrimmed=false 
 dotnet publish -c Release -r osx-x64 --self-contained /p:PublishTrimmed=false /p:PublishSingleFile=true -o ReleaseBinary/inklecate/osx64 inklecate/inklecate.csproj
 
 # Simply zip up inklecate executable and the DLLs together for each platform
-runtimeAndCompilerDLLs="ink-engine-runtime/bin/Release/net6.0/ink-engine-runtime.dll compiler/bin/Release/net6.0/ink_compiler.dll"
+runtimeAndCompilerDLLs="ink-engine-runtime/bin/Release/netstandard2.0/ink-engine-runtime.dll compiler/bin/Release/netstandard2.0/ink_compiler.dll"
 zip --junk-paths ReleaseBinary/inklecate_windows.zip ReleaseBinary/inklecate/win32/inklecate.exe $runtimeAndCompilerDLLs
 zip --junk-paths ReleaseBinary/inklecate_linux.zip  ReleaseBinary/inklecate/lin64/inklecate $runtimeAndCompilerDLLs
 zip --junk-paths ReleaseBinary/inklecate_mac.zip  ReleaseBinary/inklecate/osx64/inklecate $runtimeAndCompilerDLLs

--- a/compiler/ink_compiler.csproj
+++ b/compiler/ink_compiler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Ink</RootNamespace>
     <AssemblyName>ink_compiler</AssemblyName>
   </PropertyGroup>

--- a/ink-engine-runtime/ink-engine-runtime.csproj
+++ b/ink-engine-runtime/ink-engine-runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Ink.Runtime</RootNamespace>
     <AssemblyName>ink-engine-runtime</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Revert the change made in 5d92a5b3ba3c7a040892ff67649a58c4928adbc6. There's no reason to target net6, and doing so breaks compatibility with systems still targeting older frameworks.

I'm torn about whether we should retarget the compiler as well. It might be a good thing now that I think about it? Happy to hear your opinion about it.