### PR TITLE
WritingWithInk: add a divert in the knottier "hello world" example

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -242,6 +242,8 @@ and this on running:
 
 The following plays and compiles without error:
 
+	-> top_knot
+	
 	=== top_knot ===
 	Hello world!
 	-> END


### PR DESCRIPTION
This example shows how to make the previous example compile without errors but it did differ from the previous one in missing the divert at the beginning