### PR TITLE
Fix checking for upper bound's type in LIST_RANGE

### DIFF
--- a/ink-engine-runtime/InkList.cs
+++ b/ink-engine-runtime/InkList.cs
@@ -531,7 +531,7 @@ namespace Ink.Runtime
                 maxValue = (int)maxBound;
             else 
             {
-                if (minBound is InkList && ((InkList)minBound).Count > 0)
+                if (maxBound is InkList && ((InkList)maxBound).Count > 0)
                     maxValue = ((InkList)maxBound).maxItem.Value;
             }
 

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -3633,6 +3633,7 @@ VAR all = ()
 {all}
 {LIST_RANGE(all, 2, 3)}
 {LIST_RANGE(LIST_ALL(Numbers), Two, Six)}
+{LIST_RANGE(LIST_ALL(Numbers), Currency, Three)}
 {LIST_RANGE((Pizza, Pasta), -1, 100)} // allow out of range
 ";
 
@@ -3642,6 +3643,7 @@ VAR all = ()
 @"Pound, Pizza, Euro, Pasta, Dollar, Curry, Paella
 Euro, Pasta, Dollar, Curry
 Two, Three, Four, Five, Six
+One, Two, Three
 Pizza, Pasta
 ".Replace(Environment.NewLine, "\n"), story.ContinueMaximally());
         }


### PR DESCRIPTION
I've been slowly working on a Swift port of the ink runtime and came across a bit of code that didn't seem quite right. This pull request fixes the line and adds a test to verify it.