### PR TITLE
Swap DateTime.Now to DateTime.UtcNow

### DIFF
--- a/ink-engine-runtime/StoryState.cs
+++ b/ink-engine-runtime/StoryState.cs
@@ -464,7 +464,7 @@ namespace Ink.Runtime
             currentTurnIndex = -1;
 
             // Seed the shuffle random numbers
-            int timeSeed = DateTime.Now.Millisecond;
+            int timeSeed = DateTime.UtcNow.Millisecond;
             storySeed = (new Random (timeSeed)).Next () % 100;
             previousRandom = 0;
 


### PR DESCRIPTION
Swap DateTime.Now to DateTime.UtcNow so to avoid an OSX Desktop Permissions request on build.
This commit has been pushed to the Unity repo already.