### PR TITLE
Don't mention choiceText in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ To compile the ink, either export from Inky (File -> Export to JSON). Or if you'
         Debug.Log(story.Continue());
     
     // 3) Display story.currentChoices list, allow player to choose one
-    Debug.Log(_story.currentChoices[0].choiceText);
     _story.ChooseChoiceIndex(0);
     
     // 4) Back to 2


### PR DESCRIPTION
If my understanding is correct the `choiceText` was removed and now it's displayed with the following `story.Continue()` call