### PR TITLE
WritingWithInk: fix a Global Constants example

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1878,7 +1878,8 @@ And sometimes the numbers are useful in other ways:
 	VAR suitcase_location = HALLWAY
 
 	=== report_progress ===
-	{  secret_agent_location == suitcase_location:
+	{
+        -  secret_agent_location == suitcase_location:
 		The secret agent grabs the suitcase!
 		~ suitcase_location = HELD_BY_AGENT
 


### PR DESCRIPTION
The example was resulting in an error: Expected an "-else:" clause here...