### PR TITLE
Inklecate Unreal Editor 5 fix

### DIFF
--- a/inklecate/CommandLineTool.cs
+++ b/inklecate/CommandLineTool.cs
@@ -45,7 +45,12 @@ namespace Ink
 		CommandLineTool(string[] args)
 		{
             // Set console's output encoding to UTF-8
-            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            try { 
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
+            }
+            catch {
+                Debug.WriteLine("Unable to set console encoding to UTF8, using system default.");
+            }
 
             if (ProcessArguments (args) == false) {
                 ExitWithUsageInstructions ();


### PR DESCRIPTION
Fixed an issue that was causing Inklecate to fail when executed as a process from Unreal editor.
The console created by UE does not allow the encoding to be changed. 