### PR TITLE
Add Hiragana and Katakana character ranges

### DIFF
--- a/compiler/InkParser/InkParser_CharacterRanges.cs
+++ b/compiler/InkParser/InkParser_CharacterRanges.cs
@@ -28,6 +28,16 @@ namespace Ink
 			CharacterRange.Define('\u0080', '\u00FF', excludes: new CharacterSet());
         public static readonly CharacterRange CJKUnifiedIdeographs =
 			CharacterRange.Define('\u4E00', '\u9FFF', excludes: new CharacterSet());
+        /// <summary>
+        /// Subset of Unicode Hiragana block, excluding sound marks.
+        /// https://unicodeplus.com/block/3040
+        /// </summary>
+        public static readonly CharacterRange Hiragana = CharacterRange.Define('\u3041', '\u3096');
+        /// <summary>
+        /// Subset of Unicode Katakana block, excluding the last 3 characters.
+        /// https://unicodeplus.com/block/30A0
+        /// </summary>
+        public static readonly CharacterRange Katakana = CharacterRange.Define('\u30A0', '\u30FC');
 
         private void ExtendIdentifierCharacterRanges(CharacterSet identifierCharSet)
         {
@@ -60,6 +70,8 @@ namespace Ink
                 Korean,
 		        Latin1Supplement,
 		        CJKUnifiedIdeographs,
+                Hiragana,
+                Katakana,
             };
         }
 	}

--- a/compiler/InkParser/InkParser_CharacterRanges.cs
+++ b/compiler/InkParser/InkParser_CharacterRanges.cs
@@ -26,7 +26,7 @@ namespace Ink
 			CharacterRange.Define('\uAC00', '\uD7AF', excludes: new CharacterSet());
         public static readonly CharacterRange Latin1Supplement =
 			CharacterRange.Define('\u0080', '\u00FF', excludes: new CharacterSet());
-        public static readonly CharacterRange Chinese =
+        public static readonly CharacterRange CJKUnifiedIdeographs =
 			CharacterRange.Define('\u4E00', '\u9FFF', excludes: new CharacterSet());
 
         private void ExtendIdentifierCharacterRanges(CharacterSet identifierCharSet)
@@ -58,8 +58,8 @@ namespace Ink
                 Greek,
                 Hebrew,
                 Korean,
-		Latin1Supplement,
-		Chinese,
+		        Latin1Supplement,
+		        CJKUnifiedIdeographs,
             };
         }
 	}


### PR DESCRIPTION
1. Renamed Chinese character range to CJKUnifiedIdeographs. (Matching Unicode plane name)
2. Added Hiragana and Katakana