### PR TITLE
Fix minor typo in WritingWithInk.md

### DIFF
--- a/Documentation/WritingWithInk.md
+++ b/Documentation/WritingWithInk.md
@@ -1220,7 +1220,7 @@ The following is valid, and frequently useful.
 	*	"How did you do at the crossword, Monsieur?"[] I asked.
 		-> quitewell
 	*	I said nothing[] and neither did my Master.
-	-	We feel into companionable silence once more.
+	-	We fell into companionable silence once more.
 
 Note the level 2 gather point directly below the first option: there's nothing to gather here, really, but it gives us a handy place to divert the second option to.
 


### PR DESCRIPTION
Changed "We *feel* into companionable silence" to "We *fell* into companionable silence", which I'm assuming was the original intent.