### PR TITLE
Docs: The name and link of the social network have been replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See the [architectural overview documentation](https://github.com/inkle/ink/blob
 
 # License
 
-**ink** is released under the [MIT license](https://github.com/inkle/ink/blob/master/LICENSE.txt). Although we don't require attribution, we'd love to know if you decide to use **ink** a project! Let us know on [Twitter](http://www.twitter.com/inkleStudios) or [by email](mailto:info@inklestudios.com).
+**ink** is released under the [MIT license](https://github.com/inkle/ink/blob/master/LICENSE.txt). Although we don't require attribution, we'd love to know if you decide to use **ink** a project! Let us know on [X (formerly Twitter)](http://www.x.com/inkleStudios) or [by email](mailto:info@inklestudios.com).
 
 # Support us!
 


### PR DESCRIPTION
Hey. The name and link of the social network have been replaced