### PR TITLE
fix: update HasFunction method to discern between regular knots and function knots.

### DIFF
--- a/ink-engine-runtime/Story.cs
+++ b/ink-engine-runtime/Story.cs
@@ -1816,7 +1816,15 @@ namespace Ink.Runtime
         public bool HasFunction (string functionName)
         {
             try {
-                return KnotContainerWithName (functionName) != null;
+                Container container = KnotContainerWithName (functionName);
+                if(container != null) {
+                    return container.content.Any(c =>
+                        c is Ink.Runtime.ControlCommand controlCommand &&
+                        controlCommand.commandType == ControlCommand.CommandType.PopFunction
+                    );
+                } else {
+                    return false;
+                }
             } catch {
                 return false;
             }


### PR DESCRIPTION
### Context:

For detailed information on the problem, please see the issue posted here:
https://github.com/inkle/ink/issues/928

In short, the issue seems to be that `Story.cs`'s method `HasFunction` doesn't discern between regular knots and function knots. It calls upon `KnotContainerWithName` to check if the container is there, but this doesn't distinguish function knots.

### Solution:
Debugging and looking at the structure of a regular knot vs function knot `Container` object, the only difference I can note is that function knots contain a `PopFunction` command at the end of their contents. I've leveraged this for a (hacky) fix to check if the knot container retrieved is indeed a function. 

If you know of a better way to do this, please make a suggestion!