### PR TITLE
Hide fallback choices after loading

### DIFF
--- a/ink-engine-runtime/JsonSerialisation.cs
+++ b/ink-engine-runtime/JsonSerialisation.cs
@@ -601,6 +601,9 @@ namespace Ink.Runtime
             choice.originalThreadIndex = (int)jObj ["originalThreadIndex"];
             choice.pathStringOnChoice = jObj ["targetPath"].ToString();
             choice.tags = JArrayToTags(jObj, choice);
+            if (jObj.ContainsKey("isInvisibleDefault")) {
+                choice.isInvisibleDefault = (bool)jObj["isInvisibleDefault"];
+            }
             return choice;
         }
 
@@ -624,6 +627,7 @@ namespace Ink.Runtime
             writer.WriteProperty("originalChoicePath", choice.sourcePath);
             writer.WriteProperty("originalThreadIndex", choice.originalThreadIndex);
             writer.WriteProperty("targetPath", choice.pathStringOnChoice);
+            writer.WriteProperty("isInvisibleDefault", choice.isInvisibleDefault);
             WriteChoiceTags(writer, choice);
             writer.WriteObjectEnd();
         }

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -550,6 +550,36 @@ This is default.
         }
 
         [Test()]
+        public void TestFallbackChoicesHiddenAfterLoad()
+        {
+            Story story = CompileString(@"
+- (start)
+* [Choice 1]
+* [Choice 2]
+* -> fallback
+- After choice
+-> start
+
+== fallback ==
+This is fallback.
+-> DONE
+");
+
+            Assert.AreEqual("", story.Continue());
+            Assert.AreEqual(2, story.currentChoices.Count);
+            Assert.AreEqual("Choice 1", story.currentChoices[0].text);
+            Assert.AreEqual("Choice 2", story.currentChoices[1].text);
+
+            var savedState = story.state.ToJson();
+
+            story.state.LoadJson(savedState);
+
+            Assert.AreEqual(2, story.currentChoices.Count);
+            Assert.AreEqual("Choice 1", story.currentChoices[0].text);
+            Assert.AreEqual("Choice 2", story.currentChoices[1].text);
+        }
+
+        [Test()]
         public void TestDefaultSimpleGather()
         {
             var story = CompileString(@"


### PR DESCRIPTION
Fixes #959.

This preserves the `isInvisibleDefault` flag by adding it to serialisation and deserialisation.

Add a regression test to ensure it works correctly. I haven't tested the C# version manually, but I did as part of [my PR to inkjs](https://github.com/y-lohse/inkjs/pull/1130).

That PR contains more details about the exact analysis of the bug; I haven't duplicated it here as it's basically the same.

All tests pass:

```sh
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   358, Skipped:     0, Total:   358, Duration: 535 ms
```