### PR TITLE
Allow IPlugins to be passed directly to the compiler

### DIFF
--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -10,6 +10,7 @@ namespace Ink
         {
             public string sourceFilename;
             public List<string> pluginDirectories;
+            public List<IPlugin> plugins;
             public bool countAllVisits;
             public Ink.ErrorHandler errorHandler;
             public Ink.IFileHandler fileHandler;
@@ -25,8 +26,11 @@ namespace Ink
         {
             _inputString = inkSource;
             _options = options ?? new Options();
-            if( _options.pluginDirectories != null )
-                _pluginManager = new PluginManager (_options.pluginDirectories);
+            if( _options.pluginDirectories != null || _options.plugins != null)
+            {
+                var directories = _options.pluginDirectories != null ? _options.pluginDirectories : new List<string>();
+                _pluginManager = new PluginManager(directories, _options.plugins);
+            }
         }
 
         public Parsed.Story Parse()

--- a/compiler/Plugins/PluginManager.cs
+++ b/compiler/Plugins/PluginManager.cs
@@ -7,11 +7,11 @@ namespace Ink
 {
     public class PluginManager
     {
-        public PluginManager (List<string> pluginDirectories)
+        public PluginManager (List<string> pluginDirectories, List<IPlugin> plugins = null)
         {
-            _plugins = new List<IPlugin> ();
+            _plugins = plugins != null ? plugins : new List<IPlugin>();
 
-            foreach (string pluginName in pluginDirectories) 
+            foreach (string pluginName in pluginDirectories)
             {
                 foreach (string file in Directory.GetFiles(pluginName, "*.dll"))
                 {


### PR DESCRIPTION
While loading plugins dynamically makes sense in the most common Ink use cases, it is a bit of a pain if you're just referencing the compiler directly in a project.

I'm using the code in this PR (which should be fully backwards compatible for any existing code) to pass in instances of `IPlugin` directly to the compiler, and was wondering if it would be useful for others as well.