### PR TITLE
Save state should record if a choice is an invisible default

### DIFF
--- a/ink-engine-runtime/JsonSerialisation.cs
+++ b/ink-engine-runtime/JsonSerialisation.cs
@@ -601,6 +601,9 @@ namespace Ink.Runtime
             choice.originalThreadIndex = (int)jObj ["originalThreadIndex"];
             choice.pathStringOnChoice = jObj ["targetPath"].ToString();
             choice.tags = JArrayToTags(jObj, choice);
+            if(jObj.ContainsKey("isInvisibleDefault")) {
+                choice.isInvisibleDefault = (bool)jObj["isInvisibleDefault"];
+            }
             return choice;
         }
 
@@ -624,6 +627,9 @@ namespace Ink.Runtime
             writer.WriteProperty("originalChoicePath", choice.sourcePath);
             writer.WriteProperty("originalThreadIndex", choice.originalThreadIndex);
             writer.WriteProperty("targetPath", choice.pathStringOnChoice);
+            if(choice.isInvisibleDefault) {
+                writer.WriteProperty("isInvisibleDefault", choice.isInvisibleDefault);
+            }
             WriteChoiceTags(writer, choice);
             writer.WriteObjectEnd();
         }

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -3792,6 +3792,37 @@ VAR gatherCount = 0
             Assert.AreEqual("Should be 1 not 0: 1.\n", story.Continue());
         }
 
+        [Test()]
+        public void TestFallbackChoiceOnThreadRestoresCorrectly()
+        {
+            var storyStr =
+        @"
+-> thing1
+
+=== followed_a_choice
+->->
+
+=== thing1
+
+<- thing2
+* [A choice] <> -> followed_a_choice -> thing1
+
+=== thing2
+
+* ->
+  Got here {followed_a_choice:following a choice and a fallback}{not followed_a_choice:selected as a choice with no text}
+  -> END
+";
+
+            var story = CompileString(storyStr);
+            story.ContinueMaximally();
+            var saved = story.state.ToJson();
+            story.state.LoadJson(saved);
+            // Should be "A choice", as the fallback should not be shown
+            story.ChooseChoiceIndex(0);
+            Assert.AreEqual("Got here following a choice and a fallback\n", story.Continue());
+        }
+
         // Test for bug where after a call to ChoosePathString,
         // the callstack is not fully/cleanly reset, e.g. leaving
         // "inExpressionEvaluation" variable left to true, as set during


### PR DESCRIPTION
Hopefully a backwards compatible bug fix. Save states didn't mark invisible default choices as being, well, invisible default choices leading to them being displayed if a game was saved and reloaded while waiting for a player choice. In some cases (such as fallbacks declared in a thread) this could also lead to a choice index mismatch before and after the reload.